### PR TITLE
Upgrade tcomb-validation to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ var Form = t.form.Form;
 
 // here we are: define your domain model
 var Person = t.struct({
-  name: t.Str,              // a required string
-  surname: t.maybe(t.Str),  // an optional string
-  age: t.Num,               // a required number
-  rememberMe: t.Bool        // a boolean
+  name: t.String,              // a required string
+  surname: t.maybe(t.String),  // an optional string
+  age: t.Number,               // a required number
+  rememberMe: t.Boolean        // a boolean
 });
 
 var options = {}; // optional rendering options (see documentation)
@@ -142,8 +142,8 @@ The `Form` component behaves like a [controlled component](https://facebook.gith
 
 ```js
 var Person = t.struct({
-  name: t.Str,
-  surname: t.maybe(t.Str)
+  name: t.String,
+  surname: t.maybe(t.String)
 });
 
 var AwesomeProject = React.createClass({
@@ -203,8 +203,8 @@ where
 
 ```js
 var Type = t.struct({
-  disable: t.Bool, // if true, name field will be disabled
-  name: t.Str
+  disable: t.Boolean, // if true, name field will be disabled
+  name: t.String
 });
 
 // see the "Rendering options" section in this guide
@@ -269,10 +269,10 @@ You can get access to a field with the `getComponent(path)` API:
 
 ```js
 var Person = t.struct({
-  name: t.Str,
-  surname: t.maybe(t.Str),
-  age: t.Num,
-  rememberMe: t.Bool
+  name: t.String,
+  surname: t.maybe(t.String),
+  age: t.Number,
+  rememberMe: t.Boolean
 });
 
 var AwesomeProject = React.createClass({
@@ -313,8 +313,8 @@ By default fields are required:
 
 ```js
 var Person = t.struct({
-  name: t.Str,    // a required string
-  surname: t.Str  // a required string
+  name: t.String,    // a required string
+  surname: t.String  // a required string
 });
 ```
 
@@ -324,9 +324,9 @@ In order to create an optional field, wrap the field type with the `t.maybe` com
 
 ```js
 var Person = t.struct({
-  name: t.Str,
-  surname: t.Str,
-  email: t.maybe(t.Str) // an optional string
+  name: t.String,
+  surname: t.String,
+  email: t.maybe(t.String) // an optional string
 });
 ```
 
@@ -343,14 +343,14 @@ t.form.Form.i18n = {
 
 ### Numbers
 
-In order to create a numeric field, use the `t.Num` type:
+In order to create a numeric field, use the `t.Number` type:
 
 ```js
 var Person = t.struct({
-  name: t.Str,
-  surname: t.Str,
-  email: t.maybe(t.Str),
-  age: t.Num // a numeric field
+  name: t.String,
+  surname: t.String,
+  email: t.maybe(t.String),
+  age: t.Number // a numeric field
 });
 ```
 
@@ -358,15 +358,15 @@ tcomb-form-native will convert automatically numbers to / from strings.
 
 ### Booleans
 
-In order to create a boolean field, use the `t.Bool` type:
+In order to create a boolean field, use the `t.Boolean` type:
 
 ```js
 var Person = t.struct({
-  name: t.Str,
-  surname: t.Str,
-  email: t.maybe(t.Str),
-  age: t.Num,
-  rememberMe: t.Bool // a boolean field
+  name: t.String,
+  surname: t.String,
+  email: t.maybe(t.String),
+  age: t.Number,
+  rememberMe: t.Boolean // a boolean field
 });
 ```
 
@@ -374,15 +374,15 @@ Booleans are displayed as `SwitchIOS`s.
 
 ### Dates
 
-In order to create a date field, use the `t.Dat` type:
+In order to create a date field, use the `t.Date` type:
 
 ```js
 var Person = t.struct({
-  name: t.Str,
-  surname: t.Str,
-  email: t.maybe(t.Str),
-  age: t.Num,
-  birthDate: t.Dat // a date field
+  name: t.String,
+  surname: t.String,
+  email: t.maybe(t.String),
+  age: t.Number,
+  birthDate: t.Date // a date field
 });
 ```
 
@@ -399,18 +399,18 @@ var Gender = t.enums({
 });
 
 var Person = t.struct({
-  name: t.Str,
-  surname: t.Str,
-  email: t.maybe(t.Str),
-  age: t.Num,
-  rememberMe: t.Bool,
+  name: t.String,
+  surname: t.String,
+  email: t.maybe(t.String),
+  age: t.Numner,
+  rememberMe: t.Boolean,
   gender: Gender // enum
 });
 ```
 
 Enums are displayed as `PickerIOS`s.
 
-### Subtypes
+### Refinements
 
 A *predicate* is a function with the following signature:
 
@@ -418,20 +418,20 @@ A *predicate* is a function with the following signature:
 (x: any) => boolean
 ```
 
-You can refine a type with the `t.subtype(type, predicate)` combinator:
+You can refine a type with the `t.refinement(type, predicate)` combinator:
 
 ```js
 // a type representing positive numbers
-var Positive = t.subtype(t.Num, function (n) {
+var Positive = t.refinement(t.Number, function (n) {
   return n >= 0;
 });
 
 var Person = t.struct({
-  name: t.Str,
-  surname: t.Str,
-  email: t.maybe(t.Str),
+  name: t.String,
+  surname: t.String,
+  email: t.maybe(t.String),
   age: Positive, // refinement
-  rememberMe: t.Bool,
+  rememberMe: t.Boolean,
   gender: Gender
 });
 ```
@@ -692,8 +692,8 @@ Implementation: `DatePickerIOS`
 
 ```js
 var Person = t.struct({
-  name: t.Str,
-  birthDate: t.Dat
+  name: t.String,
+  birthDate: t.Date
 });
 ```
 
@@ -733,7 +733,7 @@ You can also override the stylesheet locally for selected fields:
 
 ```js
 var Person = t.struct({
-  name: t.Str
+  name: t.String
 });
 
 var options = {
@@ -749,7 +749,7 @@ Or per form:
 
 ```js
 var Person = t.struct({
-  name: t.Str
+  name: t.String
 });
 
 var options = {
@@ -778,7 +778,7 @@ You can also override the template locally:
 
 ```js
 var Person = t.struct({
-  name: t.Str
+  name: t.String
 });
 
 function myCustomTemplate(locals) {
@@ -837,7 +837,7 @@ Say you want a search textbox which accepts a list of keywords separated by spac
 
 ```js
 var Search = t.struct({
-  search: t.list(t.Str)
+  search: t.list(t.String)
 });
 ```
 
@@ -857,8 +857,8 @@ There is a problem though: a textbox handle only strings so we need a way to tra
 
 ```js
 var Transformer = t.struct({
-  format: t.Func, // from value to string, it must be idempotent
-  parse: t.Func   // from string to value
+  format: t.Function, // from value to string, it must be idempotent
+  parse: t.Function   // from string to value
 });
 ```
 
@@ -938,11 +938,11 @@ class MyComponent extends Component {
 // as example of transformer: this is the default transformer for textboxes
 MyComponent.transformer = {
   format: value => Nil.is(value) ? null : value,
-  parse: value => (t.Str.is(value) && value.trim() === '') || Nil.is(value) ? null : value
+  parse: value => (t.String.is(value) && value.trim() === '') || Nil.is(value) ? null : value
 };
 
 var Person = t.struct({
-  name: t.Str
+  name: t.String
 });
 
 var options = {

--- a/index.js
+++ b/index.js
@@ -1,12 +1,10 @@
 var t = require('./lib');
+var i18n = require('./lib/i18n/en');
 var templates = require('./lib/templates/bootstrap');
 var stylesheet = require('./lib/stylesheets/bootstrap');
 
 t.form.Form.templates = templates;
 t.form.Form.stylesheet = stylesheet;
-t.form.Form.i18n = {
-  optional: ' (optional)',
-  required: ''
-};
+t.form.Form.i18n = i18n;
 
 module.exports = t;

--- a/lib/components.js
+++ b/lib/components.js
@@ -16,8 +16,8 @@ function getComponent(type, options) {
   switch (type.meta.kind) {
     case 'irreducible' :
       return (
-        type === t.Bool ? Checkbox :
-        type === t.Dat ?  DatePicker :
+        type === t.Boolean ? Checkbox :
+        type === t.Date ?  DatePicker :
                           Textbox
       );
     case 'struct' :
@@ -114,7 +114,7 @@ class Component extends React.Component {
 
   getError() {
     var error = this.props.options.error;
-    return t.Func.is(error) ? error(this.state.value) : error;
+    return t.Function.is(error) ? error(this.state.value) : error;
   }
 
   hasError() {
@@ -145,7 +145,7 @@ class Component extends React.Component {
   render() {
     var locals = this.getLocals();
     // getTemplate is the only required implementation when extending Component
-    t.assert(t.Func.is(this.getTemplate), `[${SOURCE}] missing getTemplate method of component ${this.constructor.name}`);
+    t.assert(t.Function.is(this.getTemplate), `[${SOURCE}] missing getTemplate method of component ${this.constructor.name}`);
     var template = this.getTemplate();
     return template(locals);
   }
@@ -158,7 +158,7 @@ Component.transformer = {
 };
 
 function toNull(value) {
-  return (t.Str.is(value) && value.trim() === '') || Nil.is(value) ? null : value;
+  return (t.String.is(value) && value.trim() === '') || Nil.is(value) ? null : value;
 }
 
 function parseNumber(value) {
@@ -172,7 +172,7 @@ class Textbox extends Component {
   getTransformer() {
     var options = this.props.options;
     return options.transformer ? options.transformer :
-      this.typeInfo.innerType === t.Num ? Textbox.numberTransformer :
+      this.typeInfo.innerType === t.Number ? Textbox.numberTransformer :
       Textbox.transformer;
   }
 
@@ -459,7 +459,7 @@ class Form {
   }
 
   getComponent(path) {
-    path = t.Str.is(path) ? path.split('.') : path;
+    path = t.String.is(path) ? path.split('.') : path;
     return path.reduce((input, name) => input.refs[name], this.refs.input);
   }
 
@@ -471,11 +471,11 @@ class Form {
     var templates = Form.templates;
     var i18n = Form.i18n;
 
-    t.assert(t.Type.is(type), `[${SOURCE}] missing required prop type`);
-    t.assert(t.Obj.is(options), `[${SOURCE}] prop options must be an object`);
-    t.assert(t.Obj.is(stylesheet), `[${SOURCE}] missing stylesheet config`);
-    t.assert(t.Obj.is(templates), `[${SOURCE}] missing templates config`);
-    t.assert(t.Obj.is(i18n), `[${SOURCE}] missing i18n config`);
+    t.assert(t.isType(type), `[${SOURCE}] missing required prop type`);
+    t.assert(t.Object.is(options), `[${SOURCE}] prop options must be an object`);
+    t.assert(t.Object.is(stylesheet), `[${SOURCE}] missing stylesheet config`);
+    t.assert(t.Object.is(templates), `[${SOURCE}] missing templates config`);
+    t.assert(t.Object.is(i18n), `[${SOURCE}] missing i18n config`);
 
     var Component = getComponent(type, options);
 

--- a/lib/components.js
+++ b/lib/components.js
@@ -379,8 +379,9 @@ class Struct extends Component {
   onChange(fieldName, fieldValue, path) {
     var value = t.mixin({}, this.state.value);
     value[fieldName] = fieldValue;
-    this.state.value = value;
-    this.props.onChange(value, path);
+    this.setState({value}, () => {
+      this.props.onChange(value, path);
+    });
   }
 
   getTemplates() {

--- a/lib/i18n/en.js
+++ b/lib/i18n/en.js
@@ -1,0 +1,4 @@
+module.exports = {
+  optional: ' (optional)',
+  required: ''
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-form-native",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "react-native powered UI library for developing forms writing less code",
   "main": "index.js",
   "scripts": {
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/gcanti/tcomb-form-native",
   "dependencies": {
     "react-native": ">=0.9.0",
-    "tcomb-validation": "^1.0.4"
+    "tcomb-validation": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/gcanti/tcomb-form-native/issues"
   },
   "homepage": "https://github.com/gcanti/tcomb-form-native",
-  "peerDependencies": {
+  "dependencies": {
     "react-native": ">=0.9.0",
     "tcomb-validation": "^1.0.4"
   },

--- a/test/components.js
+++ b/test/components.js
@@ -4,7 +4,7 @@
 require('./node-jsx').install({harmony: true});
 
 var tape = require('tape');
-var t = require('tcomb');
+var t = require('tcomb-validation');
 var bootstrap = require('../lib/templates/bootstrap');
 
 var core = require('../lib/components');


### PR DESCRIPTION
Hi @alvaromb,

this is a PR that upgrades to tcomb-validation v2 (ref https://github.com/gcanti/tcomb-form-native/issues/68). 

The migration path should be seamless since the major version bump was caused by dropping the support for bower (i.e. types and combinators are the same).
Just notice that the short type alias (`t.Str`, `t.Num`, ...) are deprecated in favour of the long ones (`t.String`, `t.Number`, ...) and the `subtype` combinator has now a more descriptive alias `refinement`.

Could you please give it a whirl when you find the time?