### PR TITLE
Fix for Naming Collision

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://github.com/gcanti/tcomb-form-native",
   "dependencies": {
-    "react-native": ">=0.9.0",
     "tcomb-validation": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When upgrading React Native, I encountered a Naming collision from tcomb-form-native

Following the example from this react native solution. I removed react-native as a dependency and everything started working.
https://github.com/NativeSH/react-native-console-panel/issues/2