### PR TITLE
fixes #60 Adds support for Switch into Android.

### DIFF
--- a/lib/templates/bootstrap/checkbox.js
+++ b/lib/templates/bootstrap/checkbox.js
@@ -1,5 +1,5 @@
 var { React } = require('../../util');
-var { View, Text, SwitchIOS } = React;
+var { View, Text, Switch } = React;
 
 function checkbox(locals) {
 
@@ -24,7 +24,7 @@ function checkbox(locals) {
   return (
     <View style={formGroupStyle}>
       {label}
-      <SwitchIOS
+      <Switch
         ref="input"
         disabled={locals.disabled}
         onTintColor={locals.onTintColor}


### PR DESCRIPTION
Fixes https://github.com/gcanti/tcomb-form-native/issues/60.

``react-native`` dependency must be set to >=0.13.0.