### PR TITLE
change bootstrap template example URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,7 +1047,7 @@ type Message = string | ReactElement
 }
 ```
 
-For a complete example see the default template https://github.com/gcanti/tcomb-form-native/blob/master/lib/templates/bootstrap.js.
+For a complete example see the default template https://github.com/gcanti/tcomb-form-native/blob/master/lib/templates/bootstrap.
 
 ## i18n
 


### PR DESCRIPTION
Updated default template URL https://github.com/gcanti/tcomb-form-native/blob/master/lib/templates/bootstrap.js to https://github.com/gcanti/tcomb-form-native/blob/master/lib/templates/bootstrap previously referring 404 not found page.
![screen shot 2016-01-19 at 8 09 17 pm](https://cloud.githubusercontent.com/assets/13690298/12421521/a6dbfcba-bee8-11e5-9a67-93d6e255c650.png)
