### PR TITLE
Removed forced label on checkbox

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -267,8 +267,6 @@ class Checkbox extends Component {
 
   getLocals() {
     var locals = super.getLocals();
-    // checkboxes must always have a label
-    locals.label = locals.label || this.getDefaultLabel();
 
     [
       'help',


### PR DESCRIPTION
Is there any reason to still have the following? Am I missing something?
```
    // checkboxes must always have a label
    locals.label = locals.label || this.getDefaultLabel();
```
The forced label makes customizing the template harder in my opinion, i.e.:
```javascript
<View style={{ flexDirection: 'row', justifyContent: 'center' }}>
  <View style={{ flex: 1 }}><Text style={styles.headerTextSwitch}>Remember card</Text></View>
  <View style={{ flex: 1, alignItems: 'flex-end' }}>{locals.inputs.rememberCard}</View>
</View>
```
<img src="http://i.imgur.com/t44V527.png" />