### PR TITLE
closes #132 Solves HMR issue by assigning props to the Form class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,16 @@
-var t = require('./lib');
-var i18n = require('./lib/i18n/en');
-var templates = require('./lib/templates/bootstrap');
-var stylesheet = require('./lib/stylesheets/bootstrap');
+import t from './lib';
+import i18n from './lib/i18n/en';
+import templates from './lib/templates/bootstrap';
+import stylesheet from './lib/stylesheets/bootstrap';
 
 t.form.Form.templates = templates;
 t.form.Form.stylesheet = stylesheet;
 t.form.Form.i18n = i18n;
 
-module.exports = t;
+t.form.Form.defaultProps = {
+  templates: t.form.Form.templates,
+  stylesheet: t.form.Form.stylesheet,
+  i18n: t.form.Form.i18n
+};
+
+export default t;

--- a/lib/components.js
+++ b/lib/components.js
@@ -523,11 +523,11 @@ class Form extends React.Component {
 
   render() {
 
-    var type = this.props.type;
-    var options = this.props.options || nooptions;
-    var stylesheet = Form.stylesheet;
-    var templates = Form.templates;
-    var i18n = Form.i18n;
+    const type = this.props.type;
+    const options = this.props.options || nooptions;
+    const stylesheet = this.props.stylesheet || Form.stylesheet;
+    const templates = this.props.templates || Form.templates;
+    const i18n = this.props.i18n || Form.i18n;
 
     t.assert(t.isType(type), `[${SOURCE}] missing required prop type`);
     t.assert(t.Object.is(options), `[${SOURCE}] prop options must be an object`);
@@ -535,7 +535,7 @@ class Form extends React.Component {
     t.assert(t.Object.is(templates), `[${SOURCE}] missing templates config`);
     t.assert(t.Object.is(i18n), `[${SOURCE}] missing i18n config`);
 
-    var Component = getComponent(type, options);
+    const Component = getComponent(type, options);
 
     return React.createElement(Component, {
       ref: 'input',


### PR DESCRIPTION
...as suggested in the issue. 

Tests doesn't pass because of https://github.com/gcanti/tcomb-form-native/issues/134. Can be tested by changing from `require('./datepicker')` to `require('./datepicker.ios.js')`.