### PR TITLE
Add 'hidden' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,6 +934,22 @@ The following standard options are available (see http://facebook.github.io/reac
 - `mode`,
 - `timeZoneOffsetInMinutes`
 
+## Hidden Component
+
+For any component, you can set the field with the `hidden` option:
+
+```js
+var options = {
+  fields: {
+    name: {
+      hidden: true
+    }
+  }
+};
+```
+
+This will completely skip the rendering of the component, while the default value will be available for validation purposes.
+
 # Customizations
 
 ## Stylesheets

--- a/lib/components.js
+++ b/lib/components.js
@@ -163,6 +163,7 @@ class Component extends React.Component {
       onChange: this.onChange.bind(this),
       config: this.getConfig(),
       value: this.state.value,
+      hidden: this.props.options.hidden,
       stylesheet: this.getStylesheet()
     };
   }

--- a/lib/templates/bootstrap/checkbox.js
+++ b/lib/templates/bootstrap/checkbox.js
@@ -2,6 +2,9 @@ var React = require('react-native');
 var { View, Text, Switch } = React;
 
 function checkbox(locals) {
+  if (locals.hidden) {
+    return null;
+  }
 
   var stylesheet = locals.stylesheet;
   var formGroupStyle = stylesheet.formGroup.normal;

--- a/lib/templates/bootstrap/datepicker.android.js
+++ b/lib/templates/bootstrap/datepicker.android.js
@@ -2,6 +2,9 @@ var React = require('react-native');
 var { View, Text, DatePickerAndroid, TimePickerAndroid, TouchableNativeFeedback } = React;
 
 function datepicker(locals) {
+  if (locals.hidden) {
+    return null;
+  }
 
   var stylesheet = locals.stylesheet;
   var formGroupStyle = stylesheet.formGroup.normal;

--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -2,6 +2,9 @@ var React = require('react-native');
 var { View, Text, DatePickerIOS } = React;
 
 function datepicker(locals) {
+  if (locals.hidden) {
+    return null;
+  }
 
   var stylesheet = locals.stylesheet;
   var formGroupStyle = stylesheet.formGroup.normal;

--- a/lib/templates/bootstrap/select.js
+++ b/lib/templates/bootstrap/select.js
@@ -2,6 +2,9 @@ var React = require('react-native');
 var { View, Text, Picker } = React;
 
 function select(locals) {
+  if (locals.hidden) {
+    return null;
+  }
 
   var stylesheet = locals.stylesheet;
   var formGroupStyle = stylesheet.formGroup.normal;

--- a/lib/templates/bootstrap/struct.js
+++ b/lib/templates/bootstrap/struct.js
@@ -2,6 +2,9 @@ var React = require('react-native');
 var { View, Text } = React;
 
 function struct(locals) {
+  if (locals.hidden) {
+    return null;
+  }
 
   var stylesheet = locals.stylesheet;
   var fieldsetStyle = stylesheet.fieldset;

--- a/lib/templates/bootstrap/textbox.js
+++ b/lib/templates/bootstrap/textbox.js
@@ -2,6 +2,9 @@ var React = require('react-native');
 var { View, Text, TextInput } = React;
 
 function textbox(locals) {
+  if (locals.hidden) {
+    return null;
+  }
 
   var stylesheet = locals.stylesheet;
   var formGroupStyle = stylesheet.formGroup.normal;


### PR DESCRIPTION
In this way it's possible to define a default value that will be available in the `onChange` event but it's not shown in the form.

This also makes possible to validate a type with values that the user is not allowed to change.

When using redux, the complete type (with hidden values included) will be available and no extra steps should be done at the reducer workflow if the initial default value is the valid one.

To setup the option, just pass it to the field definition:

```js
var options = {
  fields: {
    name: {
      hidden: true
    }
  }
};
```
