### PR TITLE
Update components for React Native 0.25

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var t = require('tcomb-validation');
 var { humanize, merge, getTypeInfo, getOptionsOfEnum } = require('./util');
 

--- a/lib/templates/bootstrap/checkbox.js
+++ b/lib/templates/bootstrap/checkbox.js
@@ -1,5 +1,5 @@
-var React = require('react-native');
-var { View, Text, Switch } = React;
+var React = require('react');
+var { View, Text, Switch } = require('react-native');
 
 function checkbox(locals) {
   if (locals.hidden) {

--- a/lib/templates/bootstrap/datepicker.android.js
+++ b/lib/templates/bootstrap/datepicker.android.js
@@ -1,5 +1,5 @@
-var React = require('react-native');
-var { View, Text, DatePickerAndroid, TimePickerAndroid, TouchableNativeFeedback } = React;
+var React = require('react');
+var { View, Text, DatePickerAndroid, TimePickerAndroid, TouchableNativeFeedback } = require('react-native');
 
 function datepicker(locals) {
   if (locals.hidden) {

--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -1,5 +1,5 @@
-var React = require('react-native');
-var { View, Text, DatePickerIOS } = React;
+var React = require('react');
+var { View, Text, DatePickerIOS } = require('react-native');
 
 function datepicker(locals) {
   if (locals.hidden) {

--- a/lib/templates/bootstrap/select.js
+++ b/lib/templates/bootstrap/select.js
@@ -1,5 +1,5 @@
-var React = require('react-native');
-var { View, Text, Picker } = React;
+var React = require('react');
+var { View, Text, Picker } = require('react-native');
 
 function select(locals) {
   if (locals.hidden) {

--- a/lib/templates/bootstrap/struct.js
+++ b/lib/templates/bootstrap/struct.js
@@ -1,5 +1,5 @@
-var React = require('react-native');
-var { View, Text } = React;
+var React = require('react');
+var { View, Text } = require('react-native');
 
 function struct(locals) {
   if (locals.hidden) {

--- a/lib/templates/bootstrap/textbox.js
+++ b/lib/templates/bootstrap/textbox.js
@@ -1,5 +1,5 @@
-var React = require('react-native');
-var { View, Text, TextInput } = React;
+var React = require('react');
+var { View, Text, TextInput } = require('react-native');
 
 function textbox(locals) {
   if (locals.hidden) {


### PR DESCRIPTION
Removes deprecation warning when using React Native 0.25.

From the [release notes](https://github.com/facebook/react-native/releases/tag/v0.25.1):
> Requiring React API from react-native is now deprecated - [2eafcd4](https://github.com/facebook/react-native/commit/2eafcd45dbd42f750df1ab9aa3770fed5cdf11ae) [0b534d1](https://github.com/facebook/react-native/commit/0b534d1c3da9e3520bfd9b85bdd669db4d8c3b9f)