### PR TITLE
add support for lists, ref #80

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,51 @@ var options = {
 
 This will completely skip the rendering of the component, while the default value will be available for validation purposes.
 
+# Lists
+
+You can handle a list with the `t.list` combinator:
+
+```js
+const Person = t.struct({
+  name: t.String,
+  tags: t.list(t.String) // a list of strings
+});
+```
+
+## Items configuration
+
+To configure all the items in a list, set the `item` option:
+
+```js
+const Person = t.struct({
+  name: t.String,
+  tags: t.list(t.String) // a list of strings
+});
+
+const options = {
+  fields: { // <= Person options
+    tags: {
+      item: { // <= options applied to each item in the list
+        label: 'My tag'
+      }
+    }
+  }
+});
+```
+
+## Nested structures
+
+You can nest lists and structs at an arbitrary level:
+
+```js
+const Person = t.struct({
+  name: t.String,
+  surname: t.String
+});
+
+const Persons = t.list(Person);
+```
+
 # Managing unions
 
 **Example**

--- a/README.md
+++ b/README.md
@@ -951,6 +951,50 @@ var options = {
 
 This will completely skip the rendering of the component, while the default value will be available for validation purposes.
 
+# Managing unions
+
+**Example**
+
+```js
+const AccountType = t.enums.of([
+  'type 1',
+  'type 2',
+  'other'
+], 'AccountType')
+
+const KnownAccount = t.struct({
+  type: AccountType
+}, 'KnownAccount')
+
+const UnknownAccount = t.struct({
+  type: AccountType,
+  label: t.String
+}, 'UnknownAccount')
+
+// the union type
+const Account = t.union([KnownAccount, UnknownAccount], 'Account')
+
+// you must define a dispatch function returning the suitable type
+// based on the current form value
+Account.dispatch = value => {
+  return value && value.type === 'other' ? UnknownAccount : KnownAccount
+}
+
+const Type = Account
+
+// options can be a list of options, one for each type of the union
+const options = [
+  // options of the KnownAccount type
+  {
+    label: 'KnownAccount'
+  },
+  // options of theUnknownAccount type
+  {
+    label: 'UnknownAccount'
+  }
+]
+```
+
 # Customizations
 
 ## Stylesheets

--- a/lib/components.js
+++ b/lib/components.js
@@ -6,6 +6,7 @@ import {
   getTypeInfo,
   getOptionsOfEnum,
   move,
+  UIDGenerator,
   getTypeFromUnion,
   getComponentOptions
 } from './util';
@@ -14,6 +15,7 @@ const SOURCE = 'tcomb-form-native';
 const nooptions = Object.freeze({});
 const noop = function () {};
 const noobj = Object.freeze({});
+const noarr = Object.freeze([]);
 const Nil = t.Nil;
 
 function getFormComponent(type, options) {
@@ -33,6 +35,8 @@ function getFormComponent(type, options) {
       );
     case 'struct' :
       return Struct;
+    case 'list' :
+      return List;
     case 'enums' :
       return Select;
     case 'maybe' :
@@ -456,10 +460,6 @@ class Struct extends Component {
     return this.props.options.template || this.getTemplates().struct;
   }
 
-  getStylesheet() {
-    return this.props.options.stylesheet || this.props.ctx.stylesheet;
-  }
-
   getTypeProps() {
     return this.typeInfo.innerType.meta.props;
   }
@@ -494,6 +494,7 @@ class Struct extends Component {
           onChange: this.onChange.bind(this, prop),
           ctx: {
             context: ctx.context,
+            uidGenerator: ctx.uidGenerator,
             auto,
             config,
             label: humanize(prop),
@@ -519,6 +520,220 @@ class Struct extends Component {
 
 }
 
+function toSameLength(value, keys, uidGenerator) {
+  if (value.length === keys.length) {
+    return keys;
+  }
+  const ret = [];
+  for (let i = 0, len = value.length; i < len; i++ ) {
+    ret[i] = keys[i] || uidGenerator.next();
+  }
+  return ret;
+}
+
+export class List extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state.keys = this.state.value.map(() => props.ctx.uidGenerator.next());
+  }
+
+  componentWillReceiveProps(props) {
+    if (props.type !== this.props.type) {
+      this.typeInfo = getTypeInfo(props.type);
+    }
+    const value = this.getTransformer().format(props.value);
+    this.setState({
+      value,
+      keys: toSameLength(value, this.state.keys, props.ctx.uidGenerator)
+    });
+  }
+
+  isValueNully() {
+    return this.state.value.length === 0;
+  }
+
+  removeErrors() {
+    this.setState({ hasError: false });
+    Object.keys(this.refs).forEach((ref) => this.refs[ref].removeErrors());
+  }
+
+  getValue() {
+    const value = [];
+    for (let i = 0, len = this.state.value.length; i < len; i++ ) {
+      if (this.refs.hasOwnProperty(i)) {
+        value.push(this.refs[i].getValue());
+      }
+    }
+    return this.getTransformer().parse(value);
+  }
+
+  validate() {
+    const value = [];
+    let errors = [];
+    let hasError = false;
+    let result;
+
+    if (this.typeInfo.isMaybe && this.isValueNully()) {
+      this.removeErrors();
+      return new t.ValidationResult({errors: [], value: null});
+    }
+
+    for (let i = 0, len = this.state.value.length; i < len; i++ ) {
+      result = this.refs[i].validate();
+      errors = errors.concat(result.errors);
+      value.push(result.value);
+    }
+
+    // handle subtype
+    if (this.typeInfo.isSubtype && errors.length === 0) {
+      result = t.validate(value, this.props.type, this.getValidationOptions());
+      hasError = !result.isValid();
+      errors = errors.concat(result.errors);
+    }
+
+    this.setState({hasError: hasError});
+    return new t.ValidationResult({errors: errors, value: value});
+  }
+
+  onChange(value, keys, path, kind) {
+    const allkeys = toSameLength(value, keys, this.props.ctx.uidGenerator);
+    this.setState({ value, keys: allkeys, isPristine: false }, () => {
+      this.props.onChange(value, path, kind);
+    });
+  }
+
+  addItem() {
+    const value = this.state.value.concat(undefined);
+    const keys = this.state.keys.concat(this.props.ctx.uidGenerator.next());
+    this.onChange(value, keys, this.props.ctx.path.concat(value.length - 1), 'add');
+  }
+
+  onItemChange(itemIndex, itemValue, path, kind) {
+    const value = this.state.value.slice();
+    value[itemIndex] = itemValue;
+    this.onChange(value, this.state.keys, path, kind);
+  }
+
+  removeItem(i) {
+    const value = this.state.value.slice();
+    value.splice(i, 1);
+    const keys = this.state.keys.slice();
+    keys.splice(i, 1);
+    this.onChange(value, keys, this.props.ctx.path.concat(i), 'remove');
+  }
+
+  moveUpItem(i) {
+    if (i > 0) {
+      this.onChange(
+        move(this.state.value.slice(), i, i - 1),
+        move(this.state.keys.slice(), i, i - 1),
+        this.props.ctx.path.concat(i),
+        'moveUp'
+      );
+    }
+  }
+
+  moveDownItem(i) {
+    if (i < this.state.value.length - 1) {
+      this.onChange(
+        move(this.state.value.slice(), i, i + 1),
+        move(this.state.keys.slice(), i, i + 1),
+        this.props.ctx.path.concat(i),
+        'moveDown'
+      );
+    }
+  }
+
+  getTemplates() {
+    return merge(this.props.ctx.templates, this.props.options.templates);
+  }
+
+  getTemplate() {
+    return this.props.options.template || this.getTemplates().list;
+  }
+
+  getItems() {
+    const { options, ctx } = this.props;
+    const auto = this.getAuto();
+    const i18n = this.getI18n();
+    const config = this.getConfig();
+    const stylesheet = this.getStylesheet();
+    const templates = this.getTemplates();
+    const value = this.state.value;
+    return value.map((itemValue, i) => {
+      const type = this.typeInfo.innerType.meta.type;
+      const itemType = getTypeFromUnion(type, itemValue);
+      const itemOptions = getComponentOptions(options.item, noobj, itemValue, type);
+      const ItemComponent = getFormComponent(itemType, itemOptions);
+      const buttons = [];
+      if (!options.disableRemove) {
+        buttons.push({
+          type: 'remove',
+          label: i18n.remove,
+          click: this.removeItem.bind(this, i)
+        });
+      }
+      if (!options.disableOrder) {
+        buttons.push({
+          type: 'move-up',
+          label: i18n.up,
+          click: this.moveUpItem.bind(this, i)
+        });
+      }
+      if (!options.disableOrder) {
+        buttons.push({
+          type: 'move-down',
+          label: i18n.down,
+          click: this.moveDownItem.bind(this, i)
+        });
+      }
+      return {
+        input: React.createElement(ItemComponent, {
+          ref: i,
+          type: itemType,
+          options: itemOptions,
+          value: itemValue,
+          onChange: this.onItemChange.bind(this, i),
+          ctx: {
+            context: ctx.context,
+            uidGenerator: ctx.uidGenerator,
+            auto,
+            config,
+            label: ctx.label ? `${ctx.label}[${i + 1}]` : String(i + 1),
+            i18n,
+            stylesheet,
+            templates,
+            path: ctx.path.concat(i)
+          }
+        }),
+        key: this.state.keys[i],
+        buttons: buttons
+      };
+    });
+  }
+
+  getLocals() {
+    const options = this.props.options;
+    const i18n = this.getI18n();
+    const locals = super.getLocals();
+    locals.add = options.disableAdd ? null : {
+      type: 'add',
+      label: i18n.add,
+      click: this.addItem.bind(this)
+    };
+    locals.items = this.getItems();
+    locals.className = options.className;
+    return locals;
+  }
+
+}
+
+List.transformer = {
+  format: value => Nil.is(value) ? noarr : value,
+  parse: value => value
+};
+
 class Form extends React.Component {
 
   validate() {
@@ -533,6 +748,14 @@ class Form extends React.Component {
   getComponent(path) {
     path = t.String.is(path) ? path.split('.') : path;
     return path.reduce((input, name) => input.refs[name], this.refs.input);
+  }
+
+  getUIDGenerator() {
+    const seed = this._reactInternalInstance && this._reactInternalInstance._rootNodeID ?
+      this._reactInternalInstance._rootNodeID :
+      this._reactInternalInstance._nativeContainerInfo._idCounter;
+    this.uidGenerator = this.uidGenerator || new UIDGenerator(seed);
+    return this.uidGenerator;
   }
 
   render() {
@@ -553,6 +776,10 @@ class Form extends React.Component {
     const type = getTypeFromUnion(this.props.type, value);
     const options = getComponentOptions(this.props.options, noobj, value, this.props.type);
 
+    // this is in the render method because I need this._reactInternalInstance._rootNodeID in React ^0.14.0
+    // and this._reactInternalInstance._nativeContainerInfo._idCounter in React ^15.0.0
+    const uidGenerator = this.getUIDGenerator();
+
     return React.createElement(getFormComponent(type, options), {
       ref: 'input',
       type: type,
@@ -561,6 +788,7 @@ class Form extends React.Component {
       onChange: this.props.onChange || noop,
       ctx: {
         context: this.props.context,
+        uidGenerator,
         auto: 'labels',
         stylesheet,
         templates,
@@ -580,5 +808,6 @@ module.exports = {
   Select,
   DatePicker,
   Struct,
+  List: List,
   Form
 };

--- a/lib/components.js
+++ b/lib/components.js
@@ -679,10 +679,8 @@ export class List extends Component {
           type: 'move-up',
           label: i18n.up,
           click: this.moveUpItem.bind(this, i)
-        });
-      }
-      if (!options.disableOrder) {
-        buttons.push({
+        },
+        {
           type: 'move-down',
           label: i18n.down,
           click: this.moveDownItem.bind(this, i)

--- a/lib/components.js
+++ b/lib/components.js
@@ -13,9 +13,10 @@ import {
 const SOURCE = 'tcomb-form-native';
 const nooptions = Object.freeze({});
 const noop = function () {};
+const noobj = Object.freeze({});
 const Nil = t.Nil;
 
-function getComponent(type, options) {
+function getFormComponent(type, options) {
   if (options.factory) {
     return options.factory;
   }
@@ -36,7 +37,7 @@ function getComponent(type, options) {
       return Select;
     case 'maybe' :
     case 'subtype' :
-      return getComponent(type.meta.type, options);
+      return getFormComponent(type.meta.type, options);
     default :
       t.fail(`[${SOURCE}] unsupported type ${name}`);
   }
@@ -479,9 +480,12 @@ class Struct extends Component {
     const inputs = {};
     for (const prop in props) {
       if (props.hasOwnProperty(prop)) {
-        const propType = props[prop];
-        const propOptions = options.fields && options.fields[prop] ? options.fields[prop] : nooptions;
-        inputs[prop] = React.createElement(getComponent(propType, propOptions), {
+        const type = props[prop];
+        const propValue = value[prop];
+        const propType = getTypeFromUnion(type, propValue);
+        const fieldsOptions = options.fields || noobj;
+        const propOptions = getComponentOptions(fieldsOptions[prop], noobj, propValue, type);
+        inputs[prop] = React.createElement(getFormComponent(propType, propOptions), {
           key: prop,
           ref: prop,
           type: propType,
@@ -533,21 +537,23 @@ class Form extends React.Component {
 
   render() {
 
-    const type = this.props.type;
-    const options = this.props.options || nooptions;
     const stylesheet = this.props.stylesheet || Form.stylesheet;
     const templates = this.props.templates || Form.templates;
     const i18n = this.props.i18n || Form.i18n;
 
-    t.assert(t.isType(type), `[${SOURCE}] missing required prop type`);
-    t.assert(t.Object.is(options), `[${SOURCE}] prop options must be an object`);
-    t.assert(t.Object.is(stylesheet), `[${SOURCE}] missing stylesheet config`);
-    t.assert(t.Object.is(templates), `[${SOURCE}] missing templates config`);
-    t.assert(t.Object.is(i18n), `[${SOURCE}] missing i18n config`);
+    if (process.env.NODE_ENV !== 'production') {
+      t.assert(t.isType(this.props.type), `[${SOURCE}] missing required prop type`);
+      t.assert(t.maybe(t.Object).is(this.props.options) || t.Function.is(this.props.options) || t.list(t.maybe(t.Object)).is(this.props.options), `[${SOURCE}] prop options, if specified, must be an object, a function returning the options or a list of options for unions`);
+      t.assert(t.Object.is(stylesheet), `[${SOURCE}] missing stylesheet config`);
+      t.assert(t.Object.is(templates), `[${SOURCE}] missing templates config`);
+      t.assert(t.Object.is(i18n), `[${SOURCE}] missing i18n config`);
+    }
 
-    const Component = getComponent(type, options);
+    const value = this.props.value;
+    const type = getTypeFromUnion(this.props.type, value);
+    const options = getComponentOptions(this.props.options, noobj, value, this.props.type);
 
-    return React.createElement(Component, {
+    return React.createElement(getFormComponent(type, options), {
       ref: 'input',
       type: type,
       options: options,
@@ -567,7 +573,7 @@ class Form extends React.Component {
 }
 
 module.exports = {
-  getComponent,
+  getComponent: getFormComponent,
   Component,
   Textbox,
   Checkbox,

--- a/lib/components.js
+++ b/lib/components.js
@@ -1,13 +1,19 @@
-'use strict';
+import React from 'react';
+import t from 'tcomb-validation';
+import {
+  humanize,
+  merge,
+  getTypeInfo,
+  getOptionsOfEnum,
+  move,
+  getTypeFromUnion,
+  getComponentOptions
+} from './util';
 
-var React = require('react');
-var t = require('tcomb-validation');
-var { humanize, merge, getTypeInfo, getOptionsOfEnum } = require('./util');
-
-var SOURCE = 'tcomb-form-native';
-var nooptions = Object.freeze({});
-var noop = function () {};
-var Nil = t.Nil;
+const SOURCE = 'tcomb-form-native';
+const nooptions = Object.freeze({});
+const noop = function () {};
+const Nil = t.Nil;
 
 function getComponent(type, options) {
   if (options.factory) {
@@ -16,7 +22,7 @@ function getComponent(type, options) {
   if (type.getTcombFormFactory) {
     return type.getTcombFormFactory(options);
   }
-  var name = t.getTypeName(type);
+  const name = t.getTypeName(type);
   switch (type.meta.kind) {
     case 'irreducible' :
       return (
@@ -63,7 +69,7 @@ class Component extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    var should = (
+    const should = (
       nextState.value !== this.state.value ||
       nextState.hasError !== this.state.hasError ||
       nextProps.options !== this.props.options ||
@@ -103,7 +109,7 @@ class Component extends React.Component {
   }
 
   validate() {
-    var result = t.validate(this.getValue(), this.props.type, this.getValidationOptions());
+    const result = t.validate(this.getValue(), this.props.type, this.getValidationOptions());
     this.setState({hasError: !result.isValid()});
     return result;
   }
@@ -117,17 +123,14 @@ class Component extends React.Component {
   }
 
   getDefaultLabel() {
-    var ctx = this.props.ctx;
+    const ctx = this.props.ctx;
     if (ctx.label) {
       return ctx.label + (this.typeInfo.isMaybe ? this.getI18n().optional : this.getI18n().required);
     }
   }
 
   getLabel() {
-    var ctx = this.props.ctx;
-    var legend = this.props.options.legend;
-    var label = this.props.options.label;
-    label = label || legend;
+    let label = this.props.options.label || this.props.options.legend;
     if (Nil.is(label) && this.getAuto() === 'labels') {
       label = this.getDefaultLabel();
     }
@@ -136,9 +139,9 @@ class Component extends React.Component {
 
   getError() {
     if (this.hasError()) {
-      var error = this.props.options.error || this.typeInfo.getValidationErrorMessage;
+      const error = this.props.options.error || this.typeInfo.getValidationErrorMessage;
       if (t.Function.is(error)) {
-        var validationOptions = this.getValidationOptions();
+        const validationOptions = this.getValidationOptions();
         return error(this.getValue(), validationOptions.path, validationOptions.context);
       }
       return error;
@@ -172,10 +175,10 @@ class Component extends React.Component {
   }
 
   render() {
-    var locals = this.getLocals();
+    const locals = this.getLocals();
     // getTemplate is the only required implementation when extending Component
     t.assert(t.Function.is(this.getTemplate), `[${SOURCE}] missing getTemplate method of component ${this.constructor.name}`);
-    var template = this.getTemplate();
+    const template = this.getTemplate();
     return template(locals);
   }
 
@@ -191,15 +194,15 @@ function toNull(value) {
 }
 
 function parseNumber(value) {
-  var n = parseFloat(value);
-  var isNumeric = (value - n + 1) >= 0;
+  const n = parseFloat(value);
+  const isNumeric = (value - n + 1) >= 0;
   return isNumeric ? n : toNull(value);
 }
 
 class Textbox extends Component {
 
   getTransformer() {
-    var options = this.props.options;
+    const options = this.props.options;
     return options.transformer ? options.transformer :
       this.typeInfo.innerType === t.Number ? Textbox.numberTransformer :
       Textbox.transformer;
@@ -210,7 +213,7 @@ class Textbox extends Component {
   }
 
   getPlaceholder() {
-    var placeholder = this.props.options.placeholder;
+    let placeholder = this.props.options.placeholder;
     if (Nil.is(placeholder) && this.getAuto() === 'placeholders') {
       placeholder = this.getDefaultLabel();
     }
@@ -218,7 +221,7 @@ class Textbox extends Component {
   }
 
   getLocals() {
-    var locals = super.getLocals();
+    const locals = super.getLocals();
     locals.placeholder = this.getPlaceholder();
     locals.onChangeNative = this.props.options.onChange;
 
@@ -275,7 +278,7 @@ class Checkbox extends Component {
   }
 
   getLocals() {
-    var locals = super.getLocals();
+    const locals = super.getLocals();
     // checkboxes must always have a label
     locals.label = locals.label || this.getDefaultLabel();
 
@@ -300,7 +303,7 @@ Checkbox.transformer = {
 class Select extends Component {
 
   getTransformer() {
-    var options = this.props.options;
+    const options = this.props.options;
     if (options.transformer) {
       return options.transformer;
     }
@@ -320,12 +323,12 @@ class Select extends Component {
   }
 
   getOptions() {
-    var options = this.props.options;
-    var items = options.options ? options.options.slice() : getOptionsOfEnum(this.getEnum());
+    const options = this.props.options;
+    const items = options.options ? options.options.slice() : getOptionsOfEnum(this.getEnum());
     if (options.order) {
       items.sort(getComparator(options.order));
     }
-    var nullOption = this.getNullOption();
+    const nullOption = this.getNullOption();
     if (options.nullOption !== false) {
       items.unshift(nullOption);
     }
@@ -333,7 +336,7 @@ class Select extends Component {
   }
 
   getLocals() {
-    var locals = super.getLocals();
+    const locals = super.getLocals();
     locals.options = this.getOptions();
 
     [
@@ -363,7 +366,7 @@ class DatePicker extends Component {
   }
 
   getLocals() {
-    var locals = super.getLocals();
+    const locals = super.getLocals();
 
     [
       'help',
@@ -396,26 +399,25 @@ class Struct extends Component {
   }
 
   getValue() {
-    var value = {};
-    for (var ref in this.refs) {
+    const value = {};
+    for (const ref in this.refs) {
       value[ref] = this.refs[ref].getValue();
     }
     return this.getTransformer().parse(value);
   }
 
   validate() {
-
-    var value = {};
-    var errors = [];
-    var hasError = false;
-    var result;
+    let value = {};
+    let errors = [];
+    let hasError = false;
+    let result;
 
     if (this.typeInfo.isMaybe && this.isValueNully()) {
       this.removeErrors();
       return new t.ValidationResult({errors: [], value: null});
     }
 
-    for (var ref in this.refs) {
+    for (const ref in this.refs) {
       if (this.refs.hasOwnProperty(ref)) {
         result = this.refs[ref].validate();
         errors = errors.concat(result.errors);
@@ -424,7 +426,7 @@ class Struct extends Component {
     }
 
     if (errors.length === 0) {
-      var InnerType = this.typeInfo.innerType;
+      const InnerType = this.typeInfo.innerType;
       value = new InnerType(value);
       if (this.typeInfo.isSubtype && errors.length === 0) {
         result = t.validate(value, this.props.type, this.getValidationOptions());
@@ -438,7 +440,7 @@ class Struct extends Component {
   }
 
   onChange(fieldName, fieldValue, path) {
-    var value = t.mixin({}, this.state.value);
+    const value = t.mixin({}, this.state.value);
     value[fieldName] = fieldValue;
     this.setState({value}, () => {
       this.props.onChange(value, path);
@@ -466,19 +468,19 @@ class Struct extends Component {
   }
 
   getInputs() {
-    var { ctx, options } = this.props;
-    var props = this.getTypeProps();
-    var auto = this.getAuto();
-    var i18n =  this.getI18n();
-    var config = this.getConfig();
-    var value = this.state.value || {};
-    var templates = this.getTemplates();
-    var stylesheet = this.getStylesheet();
-    var inputs = {};
-    for (var prop in props) {
+    const { ctx, options } = this.props;
+    const props = this.getTypeProps();
+    const auto = this.getAuto();
+    const i18n =  this.getI18n();
+    const config = this.getConfig();
+    const value = this.state.value || {};
+    const templates = this.getTemplates();
+    const stylesheet = this.getStylesheet();
+    const inputs = {};
+    for (const prop in props) {
       if (props.hasOwnProperty(prop)) {
-        var propType = props[prop];
-        var propOptions = options.fields && options.fields[prop] ? options.fields[prop] : nooptions;
+        const propType = props[prop];
+        const propOptions = options.fields && options.fields[prop] ? options.fields[prop] : nooptions;
         inputs[prop] = React.createElement(getComponent(propType, propOptions), {
           key: prop,
           ref: prop,
@@ -503,8 +505,8 @@ class Struct extends Component {
   }
 
   getLocals() {
-    var templates = this.getTemplates();
-    var locals = super.getLocals();
+    const templates = this.getTemplates();
+    const locals = super.getLocals();
     locals.order = this.getOrder();
     locals.inputs = this.getInputs();
     locals.template = templates.struct;
@@ -520,7 +522,7 @@ class Form extends React.Component {
   }
 
   getValue() {
-    var result = this.validate();
+    const result = this.validate();
     return result.isValid() ? result.value : null;
   }
 

--- a/lib/components.js
+++ b/lib/components.js
@@ -13,6 +13,9 @@ function getComponent(type, options) {
   if (options.factory) {
     return options.factory;
   }
+  if (type.getTcombFormFactory) {
+    return type.getTcombFormFactory(options);
+  }
   var name = t.getTypeName(type);
   switch (type.meta.kind) {
     case 'irreducible' :

--- a/lib/i18n/en.js
+++ b/lib/i18n/en.js
@@ -1,4 +1,8 @@
 module.exports = {
   optional: ' (optional)',
-  required: ''
+  required: '',
+  add: 'Add',
+  remove: '✘',
+  up: '↑',
+  down: '↓'
 };

--- a/lib/stylesheets/bootstrap.js
+++ b/lib/stylesheets/bootstrap.js
@@ -120,6 +120,21 @@ var stylesheet = Object.freeze({
     error: {
       marginBottom: 4
     }
+  },
+  buttonText: {
+    fontSize: 18,
+    color: 'white',
+    alignSelf: 'center'
+  },
+  button: {
+    height: 36,
+    backgroundColor: '#48BBEC',
+    borderColor: '#48BBEC',
+    borderWidth: 1,
+    borderRadius: 8,
+    marginBottom: 10,
+    alignSelf: 'stretch',
+    justifyContent: 'center'
   }
 });
 

--- a/lib/templates/bootstrap/index.js
+++ b/lib/templates/bootstrap/index.js
@@ -3,5 +3,6 @@ module.exports = {
   checkbox: require('./checkbox'),
   select: require('./select'),
   datepicker: require('./datepicker'),
-  struct: require('./struct')
+  struct: require('./struct'),
+  list: require('./list')
 };

--- a/lib/templates/bootstrap/list.js
+++ b/lib/templates/bootstrap/list.js
@@ -1,0 +1,73 @@
+var React = require('react');
+var { View, Text, TouchableHighlight } = require('react-native');
+
+function renderRowWithoutButtons(item) {
+  return <View key={item.key}>{item.input}</View>;
+}
+
+function renderRowButton(button, stylesheet, style) {
+  return (
+    <TouchableHighlight key={button.type} style={[stylesheet.button, style]} onPress={button.click}>
+      <Text style={stylesheet.buttonText}>{button.label}</Text>
+    </TouchableHighlight>
+  );
+}
+
+function renderButtonGroup(buttons, stylesheet) {
+  return (
+    <View style={{flexDirection: 'row'}}>
+      {buttons.map(button => renderRowButton(button, stylesheet, { width: 50 }))}
+    </View>
+  );
+}
+
+function renderRow(item, stylesheet) {
+  return (
+    <View key={item.key} style={{flexDirection: 'row'}}>
+      <View style={{flex: 1}}>
+        {item.input}
+      </View>
+      <View style={{flex: 1}}>
+        {renderButtonGroup(item.buttons, stylesheet)}
+      </View>
+    </View>
+  );
+}
+
+function list(locals) {
+  if (locals.hidden) {
+    return null;
+  }
+
+  var stylesheet = locals.stylesheet;
+  var fieldsetStyle = stylesheet.fieldset;
+  var controlLabelStyle = stylesheet.controlLabel.normal;
+
+  if (locals.hasError) {
+    controlLabelStyle = stylesheet.controlLabel.error;
+  }
+
+  var label = locals.label ? <Text style={controlLabelStyle}>{locals.label}</Text> : null;
+  var error = locals.hasError && locals.error ? <Text accessibilityLiveRegion="polite" style={stylesheet.errorBlock}>{locals.error}</Text> : null;
+
+  var rows = locals.items.map(function (item) {
+    return item.buttons.length === 0 ?
+      renderRowWithoutButtons(item) :
+      renderRow(item, stylesheet);
+  });
+
+  var addButton = locals.add ?
+    renderRowButton(locals.add, stylesheet) :
+    null;
+
+  return (
+    <View style={fieldsetStyle}>
+      {label}
+      {error}
+      {rows}
+      {addButton}
+    </View>
+  );
+}
+
+module.exports = list;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,9 +1,7 @@
-'use strict';
+import t, { mixin } from 'tcomb-validation';
 
-var t = require('tcomb-validation');
-
-function getOptionsOfEnum(type) {
-  var enums = type.meta.map;
+export function getOptionsOfEnum(type) {
+  const enums = type.meta.map;
   return Object.keys(enums).map(value => {
     return {
       value,
@@ -12,13 +10,12 @@ function getOptionsOfEnum(type) {
   });
 }
 
-function getTypeInfo(type) {
-
-  var innerType = type;
-  var isMaybe = false;
-  var isSubtype = false;
-  var kind;
-  var innerGetValidationErrorMessage;
+export function getTypeInfo(type) {
+  let innerType = type;
+  let isMaybe = false;
+  let isSubtype = false;
+  let kind;
+  let innerGetValidationErrorMessage;
 
   while (innerType) {
     kind = innerType.meta.kind;
@@ -38,10 +35,10 @@ function getTypeInfo(type) {
     break;
   }
 
-  var getValidationErrorMessage = innerGetValidationErrorMessage ? function (value, path, context) {
-    var result = t.validate(value, type, {path, context});
+  const getValidationErrorMessage = innerGetValidationErrorMessage ? (value, path, context) => {
+    const result = t.validate(value, type, {path, context});
     if (!result.isValid()) {
-      for (var i = 0, len = result.errors.length; i < len; i++ ) {
+      for (let i = 0, len = result.errors.length; i < len; i++ ) {
         if (t.Function.is(result.errors[i].expected.getValidationErrorMessage)) {
           return result.errors[i].message;
         }
@@ -61,26 +58,106 @@ function getTypeInfo(type) {
 
 // thanks to https://github.com/epeli/underscore.string
 
-function underscored(s){
+function underscored(s) {
   return s.trim().replace(/([a-z\d])([A-Z]+)/g, '$1_$2').replace(/[-\s]+/g, '_').toLowerCase();
 }
 
-function capitalize(s){
+function capitalize(s) {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-function humanize(s){
+export function humanize(s) {
   return capitalize(underscored(s).replace(/_id$/, '').replace(/_/g, ' '));
 }
 
-function merge(a, b) {
-  return t.mixin(t.mixin({}, a), b, true);
+export function merge(a, b) {
+  return mixin(mixin({}, a), b, true);
 }
 
-module.exports = {
-  getOptionsOfEnum,
-  getTypeInfo,
-  humanize,
-  merge
-};
+export function move(arr, fromIndex, toIndex) {
+  const element = arr.splice(fromIndex, 1)[0];
+  arr.splice(toIndex, 0, element);
+  return arr;
+}
+
+export class UIDGenerator {
+
+  constructor(seed) {
+    this.seed = 'tfid-' + seed + '-';
+    this.counter = 0;
+  }
+
+  next() {
+    return this.seed + (this.counter++); // eslint-disable-line space-unary-ops
+  }
+
+}
+
+function containsUnion(type) {
+  switch (type.meta.kind) {
+  case 'union' :
+    return true;
+  case 'maybe' :
+  case 'subtype' :
+    return containsUnion(type.meta.type);
+  default :
+    return false;
+  }
+}
+
+function getUnionConcreteType(type, value) {
+  const kind = type.meta.kind;
+  if (kind === 'union') {
+    const concreteType = type.dispatch(value);
+    if (process.env.NODE_ENV !== 'production') {
+      t.assert(t.isType(concreteType), () => 'Invalid value ' + t.assert.stringify(value) + ' supplied to ' + t.getTypeName(type) + ' (no constructor returned by dispatch)' );
+    }
+    return concreteType;
+  } else if (kind === 'maybe') {
+    return t.maybe(getUnionConcreteType(type.meta.type, value), type.meta.name);
+  } else if (kind === 'subtype') {
+    return t.subtype(getUnionConcreteType(type.meta.type, value), type.meta.predicate, type.meta.name);
+  }
+}
+
+export function getTypeFromUnion(type, value) {
+  if (containsUnion(type)) {
+    return getUnionConcreteType(type, value);
+  }
+  return type;
+}
+
+function getUnion(type) {
+  if (type.meta.kind === 'union') {
+    return type;
+  }
+  return getUnion(type.meta.type);
+}
+
+function findIndex(arr, element) {
+  for (let i = 0, len = arr.length; i < len; i++ ) {
+    if (arr[i] === element) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+export function getComponentOptions(options, defaultOptions, value, type) {
+  if (t.Nil.is(options)) {
+    return defaultOptions;
+  }
+  if (t.Function.is(options)) {
+    return options(value);
+  }
+  if (t.Array.is(options) && containsUnion(type)) {
+    const union = getUnion(type);
+    const concreteType = union.dispatch(value);
+    const index = findIndex(union.meta.types, concreteType);
+    // recurse
+    return getComponentOptions(options[index], defaultOptions, value, concreteType);
+  }
+  return options;
+}
+
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "babel-core": "5.8.34",
     "eslint": "0.23.0",
     "eslint-plugin-react": "2.5.2",
-    "mockery": "1.4.0",
     "react": "^15.0.0",
     "tape": "3.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint": "0.23.0",
     "eslint-plugin-react": "2.5.2",
     "mockery": "1.4.0",
-    "react": "0.14.7",
+    "react": "^15.0.0",
     "tape": "3.5.0"
   },
   "tags": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-form-native",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "react-native powered UI library for developing forms writing less code",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,5 @@
 'use strict';
 
-var mockery = require('mockery');
-mockery.enable();
-mockery.warnOnUnregistered(false);
-mockery.registerSubstitute('react-native', 'react');
-
 var tape = require('tape');
 var t = require('tcomb-validation');
 var bootstrap = {
@@ -1119,6 +1114,3 @@ tape('DatePicker', function (tape) {
   });
 
 });
-
-mockery.deregisterAll();
-mockery.disable();


### PR DESCRIPTION
This adds support for lists. 

Builds on my previous PR https://github.com/gcanti/tcomb-form-native/pull/172

It's a direct porting of the same `tcomb-form` feature, this means you can handle lists of strings, lists of structs, lists of lists, lists of unions of lists of structs... etc etc etc :)

The engine (the `List` component in `components.js`) should be ok, but I need some help with the default template: I put up a bare and ugly one, just for having something to show. 

I'm a web developer :) when it comes to mobile development and RN it's better having someone more experienced than me to jump in and change the code.