### PR TITLE
Updating datepicker.ios.js to temporarily disable the inaccurate warnings until Facebook fixes this issue.

### DIFF
--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -1,6 +1,10 @@
 var React = require('react');
 var { View, Text, DatePickerIOS } = require('react-native');
-
+// Added by to get rid of the invalid messages. See https://github.com/facebook/react-native/issues/4547
+DatePickerIOS.propTypes.date = React.PropTypes.any.isRequired;
+DatePickerIOS.propTypes.onDateChange = React.PropTypes.func;
+DatePickerIOS.propTypes.maximumDate = React.PropTypes.any;
+DatePickerIOS.propTypes.minimumDate = React.PropTypes.any;
 function datepicker(locals) {
   if (locals.hidden) {
     return null;


### PR DESCRIPTION


Updating datepicker.ios.js to temporarily disable the inaccurate warnings until Facebook fixes this issue.
https://github.com/facebook/react-native/issues/2397