### PR TITLE
Incorrect nullOption documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -903,7 +903,7 @@ You can customize the null option with the `nullOption` option:
 var options = {
   fields: {
     gender: {
-      nullOption: {value: '', label: 'Choose your gender'}
+      nullOption: {value: '', text: 'Choose your gender'}
     }
   }
 };


### PR DESCRIPTION
Null option label field is `text` not `label`.

Source code line: https://github.com/gcanti/tcomb-form-native/blob/master/lib/components.js#L335