### PR TITLE
Ability to style picker container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ The bundled template will render an iOS `UIPickerView` component, but collapsed 
 | `animation` | The animation to collapse the date picker. Defaults to `Animated.timing`. |
 | `animationConfig` | The animation configuration object. Defaults to `{duration: 200}` for the default animation. |
 
-For the collapsible customization, look at the `pickerTouchable` and `pickerValue` keys in the stylesheet file.
+For the collapsible customization, look at the `pickerContainer`, `pickerTouchable` and `pickerValue` keys in the stylesheet file.
 
 ### Refinements
 

--- a/lib/stylesheets/bootstrap.js
+++ b/lib/stylesheets/bootstrap.js
@@ -4,6 +4,7 @@
 
 */
 'use strict';
+import {Platform} from 'react-native';
 
 var LABEL_COLOR = '#000000';
 var INPUT_COLOR = '#000000';
@@ -103,13 +104,40 @@ var stylesheet = Object.freeze({
       marginBottom: 4
     }
   },
+  pickerContainer: {
+    normal: {
+      marginBottom: 4,
+      borderRadius: 4,
+      borderColor: BORDER_COLOR,
+      borderWidth: 1,
+    },
+    error: {
+      marginBottom: 4,
+      borderRadius: 4,
+      borderColor: ERROR_COLOR,
+      borderWidth: 1,
+    },
+    open: {
+      // Alter styles when select container is open
+    },
+  },
   select: {
     normal: {
-      marginBottom: 4
+      ...Platform.select({
+        android: {
+          paddingLeft: 7,
+          color: INPUT_COLOR,
+        }
+      })
     },
     // the style applied when a validation error occours
     error: {
-      marginBottom: 4
+      ...Platform.select({
+        android: {
+          paddingLeft: 7,
+          color: INPUT_COLOR,
+        }
+      })
     }
   },
   pickerTouchable: {
@@ -122,6 +150,10 @@ var stylesheet = Object.freeze({
       height: 44,
       flexDirection: 'row',
       alignItems: 'center'
+    },
+    active: {
+      borderBottomWidth: 1,
+      borderColor: BORDER_COLOR,
     }
   },
   pickerValue: {

--- a/lib/stylesheets/bootstrap.js
+++ b/lib/stylesheets/bootstrap.js
@@ -123,19 +123,25 @@ var stylesheet = Object.freeze({
   },
   select: {
     normal: {
-      ...Platform.select({
+      Platform.select({
         android: {
           paddingLeft: 7,
           color: INPUT_COLOR,
+        },
+        ios: {
+
         }
       })
     },
     // the style applied when a validation error occours
     error: {
-      ...Platform.select({
+      Platform.select({
         android: {
           paddingLeft: 7,
           color: INPUT_COLOR,
+        },
+        ios: {
+
         }
       })
     }

--- a/lib/stylesheets/bootstrap.js
+++ b/lib/stylesheets/bootstrap.js
@@ -16,10 +16,6 @@ var DISABLED_BACKGROUND_COLOR = '#eeeeee';
 var FONT_SIZE = 17;
 var FONT_WEIGHT = '500';
 
-var platformSelect = (styles) => {
-  return Platform.select(styles);
-};
-
 var stylesheet = Object.freeze({
   fieldset: {},
   // the style applied to the container of all inputs
@@ -126,29 +122,25 @@ var stylesheet = Object.freeze({
     },
   },
   select: {
-    normal: {
-      platformSelect({
-        android: {
-          paddingLeft: 7,
-          color: INPUT_COLOR,
-        },
-        ios: {
+    normal: Platform.select({
+      android: {
+        paddingLeft: 7,
+        color: INPUT_COLOR,
+      },
+      ios: {
 
-        }
-      })
-    },
+      }
+    }),
     // the style applied when a validation error occours
-    error: {
-      platformSelect({
-        android: {
-          paddingLeft: 7,
-          color: ERROR_COLOR,
-        },
-        ios: {
+    error: Platform.select({
+      android: {
+        paddingLeft: 7,
+        color: ERROR_COLOR,
+      },
+      ios: {
 
-        }
-      })
-    }
+      }
+    })
   },
   pickerTouchable: {
     normal: {

--- a/lib/stylesheets/bootstrap.js
+++ b/lib/stylesheets/bootstrap.js
@@ -4,7 +4,8 @@
 
 */
 'use strict';
-import {Platform} from 'react-native';
+
+import { Platform } from 'react-native';
 
 var LABEL_COLOR = '#000000';
 var INPUT_COLOR = '#000000';
@@ -112,10 +113,7 @@ var stylesheet = Object.freeze({
       borderWidth: 1,
     },
     error: {
-      marginBottom: 4,
-      borderRadius: 4,
       borderColor: ERROR_COLOR,
-      borderWidth: 1,
     },
     open: {
       // Alter styles when select container is open

--- a/lib/stylesheets/bootstrap.js
+++ b/lib/stylesheets/bootstrap.js
@@ -16,6 +16,10 @@ var DISABLED_BACKGROUND_COLOR = '#eeeeee';
 var FONT_SIZE = 17;
 var FONT_WEIGHT = '500';
 
+var platformSelect = (styles) => {
+  return Platform.select(styles);
+};
+
 var stylesheet = Object.freeze({
   fieldset: {},
   // the style applied to the container of all inputs
@@ -123,7 +127,7 @@ var stylesheet = Object.freeze({
   },
   select: {
     normal: {
-      Platform.select({
+      platformSelect({
         android: {
           paddingLeft: 7,
           color: INPUT_COLOR,
@@ -135,10 +139,10 @@ var stylesheet = Object.freeze({
     },
     // the style applied when a validation error occours
     error: {
-      Platform.select({
+      platformSelect({
         android: {
           paddingLeft: 7,
-          color: INPUT_COLOR,
+          color: ERROR_COLOR,
         },
         ios: {
 

--- a/lib/templates/bootstrap/select.android.js
+++ b/lib/templates/bootstrap/select.android.js
@@ -9,7 +9,7 @@ function select(locals) {
   var stylesheet = locals.stylesheet;
   var formGroupStyle = stylesheet.formGroup.normal;
   var controlLabelStyle = stylesheet.controlLabel.normal;
-  var selectStyle = stylesheet.select.normal;
+  var selectStyle = Object.assign({}, stylesheet.select.normal, stylesheet.pickerContainer.normal);
   var helpBlockStyle = stylesheet.helpBlock.normal;
   var errorBlockStyle = stylesheet.errorBlock;
 

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -16,8 +16,11 @@ class CollapsiblePickerIOS extends React.Component {
   render() {
     const locals = this.props.locals;
     const { stylesheet } = locals;
+    let pickerContainer = stylesheet.pickerContainer.normal;
+    let pickerContainerOpen = stylesheet.pickerContainer.open;
     let selectStyle = stylesheet.select.normal;
     let touchableStyle = stylesheet.pickerTouchable.normal;
+    let touchableStyleActive = stylesheet.pickerTouchable.active;
     let pickerValue = stylesheet.pickerValue.normal;
     if (locals.hasError) {
       selectStyle = stylesheet.select.error;
@@ -43,8 +46,8 @@ class CollapsiblePickerIOS extends React.Component {
 
     const height = (this.state.isCollapsed) ? 0 : UIPICKER_HEIGHT;
     return (
-      <View>
-        <TouchableOpacity style={touchableStyle}
+      <View style={[pickerContainer, (!this.state.isCollapsed) ? pickerContainerOpen : {}]}>
+        <TouchableOpacity style={[touchableStyle, this.state.isCollapsed ? {} : touchableStyleActive]}
           onPress={() => {
             animation(this.state.height, Object.assign({
               toValue: (this.state.isCollapsed) ? UIPICKER_HEIGHT : 0


### PR DESCRIPTION
Added new styling to the view containing the iOS picker to allow for styling the background/border behind and around the picker. Helps contain the component instead of the picker feeling entirely separate to that of the touch handler.
