### PR TITLE
adding docs for options in nested structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,36 @@ const Person = t.struct({
 const Persons = t.list(Person);
 ```
 
+If you want to provide options for your nested structures they must be nested
+following the type structure. Here is an example:
+
+```js
+const Person = t.struct({
+  name: t.Struct,
+  position: t.Struct({
+    latitude: t.Number,
+    longitude: t.Number
+  });
+});
+
+const options = {
+  fields: { // <= Person options
+    name: {
+        label: 'name label'
+    }
+    position: {
+        fields: {
+            // Note that latitude is not not directly nested in position, 
+            // but in the fields property
+            latitude: { 
+                label: 'My position label'
+            }
+        }
+    }
+  }
+});
+```
+
 ## Internationalization
 
 You can override the default language (english) with the `i18n` option:


### PR DESCRIPTION
It took me some time to realize why my placeholders for my nested structures were not shown in the form. After searching the issues I found this:
https://github.com/gcanti/tcomb-form-native/issues/220

And I think that this information belongs in the docs.