### PR TITLE
Added a possibility to change the mode of DatePickerAndroid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -963,7 +963,7 @@ The following options are similar to the `Textbox` component's ones:
 - `help`
 - `error`
 
-### Other standard options
+### Other standard options (iOS)
 
 The following standard options are available (see http://facebook.github.io/react-native/docs/datepickerios.html):
 
@@ -972,6 +972,14 @@ The following standard options are available (see http://facebook.github.io/reac
 - `minuteInterval`,
 - `mode`,
 - `timeZoneOffsetInMinutes`
+
+### Other standard options (Android)
+
+The following standard options are available (see http://facebook.github.io/react-native/docs/datepickerandroid.html):
+
+- `maximumDate`,
+- `minimumDate`,
+- `mode` (using the `androidMode` option)
 
 ## Hidden Component
 

--- a/lib/components.js
+++ b/lib/components.js
@@ -386,6 +386,7 @@ class DatePicker extends Component {
   getLocals() {
     const locals = super.getLocals();
     [
+      'androidMode',
       'help',
       'maximumDate',
       'minimumDate',

--- a/lib/templates/bootstrap/datepicker.android.js
+++ b/lib/templates/bootstrap/datepicker.android.js
@@ -76,6 +76,9 @@ function datepicker(locals) {
             if (locals.maximumDate) {
               config.maxDate = locals.maximumDate;
             }
+            if (locals.androidMode) {
+              config.mode = locals.androidMode;
+            }
             DatePickerAndroid.open(config)
             .then(function (date) {
               if (date.action !== DatePickerAndroid.dismissedAction) {


### PR DESCRIPTION
This commit adds a possibility to change the mode option of the DatePickerAndroid.
This allows using the spinner picker instead of the default one by setting `androidMode` to`spinner`.