### PR TITLE
Added option to change dialog mode for DatePickerAndroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ When using a `t.Date` type in Android, it can be configured through a `config` o
 |-----|-------|
 | ``background`` | Determines the type of background drawable that's going to be used to display feedback. Optional, defaults to ``TouchableNativeFeedback.SelectableBackground``. |
 | ``format`` | A ``(date) => String(date)`` kind of function to provide a custom date format parsing to display the value. Optional, defaults to ``(date) => String(date)``.
+| ``dialogMode`` | Determines the type of datepicker mode for Android (`default`, `spinner` or `calendar`).
 
 ### Enums
 

--- a/lib/templates/bootstrap/datepicker.android.js
+++ b/lib/templates/bootstrap/datepicker.android.js
@@ -32,15 +32,20 @@ function datepicker(locals) {
    * Check config locals for Android datepicker.
    * ``locals.config.background``: `TouchableNativeFeedback` background prop
    * ``locals.config.format``: Date format function
+   * ``locals.config.dialogMode``: 'calendar', 'spinner', 'default'
    */
   var formattedValue = String(locals.value);
   var background = TouchableNativeFeedback.SelectableBackground(); // eslint-disable-line new-cap
+  var dialogMode = 'default';
   if (locals.config) {
     if (locals.config.format) {
       formattedValue = locals.config.format(locals.value);
     }
     if (locals.config.background) {
       background = locals.config.background;
+    }
+    if (locals.config.dialogMode) {
+      dialogMode = locals.config.dialogMode;
     }
   }
 

--- a/lib/templates/bootstrap/datepicker.android.js
+++ b/lib/templates/bootstrap/datepicker.android.js
@@ -73,7 +73,8 @@ function datepicker(locals) {
             });
           } else {
             let config = {
-              date: locals.value || new Date()
+              date: locals.value || new Date(),
+              mode: dialogMode
             };
             if (locals.minimumDate) {
               config.minDate = locals.minimumDate;


### PR DESCRIPTION
Let users choose between the `calendar` and `spinner` modes of [DatePickerAndroid](http://facebook.github.io/react-native/docs/datepickerandroid.html). Default is `calendar`.

The spinner mode is quite useful for fields like birthday while the display of weekdays is not as important and users need to go back in time a few years quickly. It's also more consistent with the UX of the `DatePickerIOS`.

**Spinner**:
![image](https://cloud.githubusercontent.com/assets/855995/23995648/cb7f874a-0a4a-11e7-8b4d-6c083f53e25a.png)

**Calendar**:
![image](https://cloud.githubusercontent.com/assets/855995/23995609/acf274ae-0a4a-11e7-9e7c-5122754213c4.png)

