### PR TITLE
Add proper border color to select.ios when there is an error

### DIFF
--- a/lib/stylesheets/bootstrap.js
+++ b/lib/stylesheets/bootstrap.js
@@ -124,7 +124,10 @@ var stylesheet = Object.freeze({
       borderWidth: 1
     },
     error: {
-      borderColor: ERROR_COLOR
+      marginBottom: 4,
+      borderRadius: 4,
+      borderColor: ERROR_COLOR,
+      borderWidth: 1
     },
     open: {
       // Alter styles when select container is open

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -23,6 +23,7 @@ class CollapsiblePickerIOS extends React.Component {
     let touchableStyleActive = stylesheet.pickerTouchable.active;
     let pickerValue = stylesheet.pickerValue.normal;
     if (locals.hasError) {
+      pickerContainer = stylesheet.pickerContainer.error;
       selectStyle = stylesheet.select.error;
       touchableStyle = stylesheet.pickerTouchable.error;
       pickerValue = stylesheet.pickerValue.error;


### PR DESCRIPTION
Fixes #342 ("Error style doesn't work on select component border line")

![image](https://cloud.githubusercontent.com/assets/855995/24830265/a457914a-1c82-11e7-89f3-a1acb7246bbd.png)
