### PR TITLE
Android timepicker always open the current time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ AwesomeProject.xcodeproj
 AwesomeProjectTests
 index.ios.js
 iOS
+.idea

--- a/lib/templates/bootstrap/datepicker.android.js
+++ b/lib/templates/bootstrap/datepicker.android.js
@@ -58,7 +58,13 @@ function datepicker(locals) {
         background={background}
         onPress={function () {
           if (datePickerMode === 'time') {
-            TimePickerAndroid.open({is24Hour: true})
+            const now = new Date();
+            const isDate = locals.value && locals.value instanceof Date;
+            let setTime = {
+              hour: (isDate) ? locals.value.getHours() : now.getHours(),
+              minute: (isDate) ? locals.value.getMinutes() : now.getMinutes()
+            };
+            TimePickerAndroid.open({is24Hour: true, hour: setTime.hour, minute: setTime.minute})
             .then(function (time) {
               if (time.action !== TimePickerAndroid.dismissedAction) {
                 const newTime = new Date();


### PR DESCRIPTION
### Expected behaviour
When edit time, android time picker must show the time based on the time of the data

### Actual behaviour
Android date picker always show the current time

### Solution
Change file datepicker.android.js 
