### PR TITLE
add list config options for button position

### DIFF
--- a/README.md
+++ b/README.md
@@ -1066,6 +1066,32 @@ const options = {
 });
 ```
 
+### Setting list button group layout
+
+You can set the config option of a list with the following options to change the move/remove button group layout:
+
+```
+const options = {
+  fields: { // <= Person options
+    tags: {
+      item: {
+        label: 'My tag',
+        config: {
+          buttonGroupPosition: 'before',
+          buttonGroupFlexDirection: 'colomn'
+        }
+      }
+    }
+  }
+});
+```
+
+#### Defaults
+
+By default `buttonGroupPosition` is not defined, which will result in the button group being placed *after* the item fields. Pass `'before'` to position the buttons before the item fields.
+
+By default `buttonGroupFlexDirection` is set to `'row'`, which sets the `flexDirection` style attribute of the buttom group and item fields' container. Pass `'columns'` to position the button group and item fields vertically.
+
 ## Nested structures
 
 You can nest lists and structs at an arbitrary level:

--- a/README.md
+++ b/README.md
@@ -1072,13 +1072,13 @@ You can set the config option of a list with the following options to change the
 
 ```
 const options = {
-  fields: { // <= Person options
+  fields: {
     tags: {
       item: {
         label: 'My tag',
         config: {
-          buttonGroupPosition: 'before',
-          buttonGroupFlexDirection: 'colomn'
+          buttonGroupPosition: 'before', // <===
+          buttonGroupFlexDirection: 'colomn' // <===
         }
       }
     }

--- a/lib/templates/bootstrap/list.js
+++ b/lib/templates/bootstrap/list.js
@@ -22,8 +22,22 @@ function renderButtonGroup(buttons, stylesheet) {
 }
 
 function renderRow(item, stylesheet) {
+  var buttonGroupFlexDirection = (item.config && item.config.buttonGroupFlexDirection) || 'row';
+  var buttonGroupPosition = (item.config && item.config.buttonGroupPosition);
+  if (buttonGroupPosition === 'before') {
+    return (
+      <View key={item.key} style={{flexDirection: buttonGroupFlexDirection}}>
+        <View style={{flex: 1}}>
+          {renderButtonGroup(item.buttons, stylesheet)}
+        </View>
+        <View style={{flex: 1}}>
+          {item.input}
+        </View>
+      </View>
+    );
+  }
   return (
-    <View key={item.key} style={{flexDirection: 'row'}}>
+    <View key={item.key} style={{flexDirection: buttonGroupFlexDirection}}>
       <View style={{flex: 1}}>
         {item.input}
       </View>


### PR DESCRIPTION
**What**
- Check `locals` for some basic positioning options for the move / remove list buttons.

**Why**
- It's nice to have some easy high level control if these items.

**How**
- Check `locals.config` for `buttonGroupPosition` and `buttonGroupFlexDirection` options. By default, behavior is unchanged.

**PS**
I was not able to set `t.form.Form.templates` successfully. My templates were ignored and the default templates were rendered. Is this a known issue elsewhere?

**Screenshots**
(please ignore the heinous design)

` buttonGroupPosition: 'before', buttonGroupFlexDirection: 'row' `
![simulator screen shot jul 20 2017 8 39 41 pm](https://user-images.githubusercontent.com/3526083/28445684-a0fa89c6-6d8b-11e7-8cf8-ba147a7c82b3.png)

` buttonGroupPosition: 'before', buttonGroupFlexDirection: 'column' `
![simulator screen shot jul 20 2017 8 39 30 pm](https://user-images.githubusercontent.com/3526083/28445686-a0fd7c9e-6d8b-11e7-8272-a8f6d4ea3bbc.png)

` buttonGroupPosition: 'after', buttonGroupFlexDirection: 'column' `
![simulator screen shot jul 20 2017 8 39 08 pm](https://user-images.githubusercontent.com/3526083/28445685-a0fc73d0-6d8b-11e7-8acc-acc6685fdaed.png)

