### PR TITLE
Updated React to 15.6.1 and added PropTypes Dependency

### DIFF
--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Animated, View, TouchableOpacity, Text, DatePickerIOS } from 'react-native';
 
 const UIPICKER_HEIGHT = 216;

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Animated, View, TouchableOpacity, Text, Picker } from 'react-native';
 
 const UIPICKER_HEIGHT = 216;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-core": "5.8.34",
     "eslint": "0.23.0",
     "eslint-plugin-react": "2.5.2",
-    "react": "^15.0.0",
+    "react": "^15.6.1",
     "prop-types": "^15.5.10",
     "tape": "3.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint": "0.23.0",
     "eslint-plugin-react": "2.5.2",
     "react": "^15.0.0",
+    "prop-types": "^15.5.10",
     "tape": "3.5.0"
   },
   "tags": [


### PR DESCRIPTION
Our app is now using the following dependencies, and we have issues with tcomb not using the seperate prop-types package.

- "tcomb-form-native": "^0.6.7"
- "prop-types": "^15.5.8",
- "react": "^16.0.0-alpha.12",
- "react-native": "^0.47.1",
