### PR TITLE
Close iOS Select when selection is made

### DIFF
--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -43,6 +43,13 @@ class CollapsiblePickerIOS extends React.Component {
       }
     }
 
+    let closePicker = () => {
+      animation(this.state.height, Object.assign({
+        toValue: (this.state.isCollapsed) ? UIPICKER_HEIGHT : 0
+      }, animationConfig)).start();
+      this.setState({isCollapsed: !this.state.isCollapsed});
+    }
+
     const options = locals.options.map(({value, text}) => <Picker.Item key={value} value={value} label={text} />);
     const selectedOption = locals.options.find(option => option.value === locals.value);
 
@@ -50,12 +57,7 @@ class CollapsiblePickerIOS extends React.Component {
     return (
       <View style={[pickerContainer, (!this.state.isCollapsed) ? pickerContainerOpen : {}]}>
         <TouchableOpacity style={[touchableStyle, this.state.isCollapsed ? {} : touchableStyleActive]}
-          onPress={() => {
-            animation(this.state.height, Object.assign({
-              toValue: (this.state.isCollapsed) ? UIPICKER_HEIGHT : 0
-            }, animationConfig)).start();
-            this.setState({isCollapsed: !this.state.isCollapsed});
-          }}>
+          onPress={closePicker}>
           <Text style={pickerValue}>
             {selectedOption.text}
           </Text>
@@ -66,7 +68,10 @@ class CollapsiblePickerIOS extends React.Component {
             ref="input"
             style={selectStyle}
             selectedValue={locals.value}
-            onValueChange={locals.onChange}
+            onValueChange={(itemValue, itemPosition) => {
+              closePicker()
+              locals.onChange(itemValue, itemPosition)
+            }}
             help={locals.help}
             enabled={locals.enabled}
             mode={locals.mode}

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -69,7 +69,8 @@ class CollapsiblePickerIOS extends React.Component {
             style={selectStyle}
             selectedValue={locals.value}
             onValueChange={(itemValue, itemPosition) => {
-              closePicker()
+              clearTimeout(this.closePickerTimeout)
+              this.closePickerTimeout = setTimeout(closePicker, 800)
               locals.onChange(itemValue, itemPosition)
             }}
             help={locals.help}

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -43,11 +43,20 @@ class CollapsiblePickerIOS extends React.Component {
       }
     }
 
-    let closePicker = () => {
+    let togglePicker = () => {
       animation(this.state.height, Object.assign({
         toValue: (this.state.isCollapsed) ? UIPICKER_HEIGHT : 0
       }, animationConfig)).start();
       this.setState({isCollapsed: !this.state.isCollapsed});
+    };
+
+    let closePicker = () => {
+      if (!this.state.isCollapsed) {
+        animation(this.state.height, Object.assign({
+          toValue: 0
+        }, animationConfig)).start();
+        this.setState({isCollapsed: true});
+      }
     };
 
     const options = locals.options.map(({value, text}) => <Picker.Item key={value} value={value} label={text} />);
@@ -57,7 +66,7 @@ class CollapsiblePickerIOS extends React.Component {
     return (
       <View style={[pickerContainer, (!this.state.isCollapsed) ? pickerContainerOpen : {}]}>
         <TouchableOpacity style={[touchableStyle, this.state.isCollapsed ? {} : touchableStyleActive]}
-          onPress={closePicker}>
+          onPress={togglePicker}>
           <Text style={pickerValue}>
             {selectedOption.text}
           </Text>
@@ -66,7 +75,7 @@ class CollapsiblePickerIOS extends React.Component {
           onMoveShouldSetResponder={() => {
             clearTimeout(this.closePickerTimeout);
             return true;
-           }}
+          }}
           style={{height: this.state.height, overflow: 'hidden'}}
         >
           <Picker

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -62,7 +62,13 @@ class CollapsiblePickerIOS extends React.Component {
             {selectedOption.text}
           </Text>
         </TouchableOpacity>
-        <Animated.View style={{height: this.state.height, overflow: 'hidden'}}>
+        <Animated.View 
+          onMoveShouldSetResponder={() => {
+            clearTimeout(this.closePickerTimeout)
+            return true
+           }}
+          style={{height: this.state.height, overflow: 'hidden'}}
+        >
           <Picker
             accessibilityLabel={locals.label}
             ref="input"
@@ -70,7 +76,7 @@ class CollapsiblePickerIOS extends React.Component {
             selectedValue={locals.value}
             onValueChange={(itemValue, itemPosition) => {
               clearTimeout(this.closePickerTimeout)
-              this.closePickerTimeout = setTimeout(closePicker, 2000)
+              this.closePickerTimeout = setTimeout(closePicker, 500)
               locals.onChange(itemValue, itemPosition)
             }}
             help={locals.help}

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -48,7 +48,7 @@ class CollapsiblePickerIOS extends React.Component {
         toValue: (this.state.isCollapsed) ? UIPICKER_HEIGHT : 0
       }, animationConfig)).start();
       this.setState({isCollapsed: !this.state.isCollapsed});
-    }
+    };
 
     const options = locals.options.map(({value, text}) => <Picker.Item key={value} value={value} label={text} />);
     const selectedOption = locals.options.find(option => option.value === locals.value);
@@ -62,10 +62,10 @@ class CollapsiblePickerIOS extends React.Component {
             {selectedOption.text}
           </Text>
         </TouchableOpacity>
-        <Animated.View 
+        <Animated.View
           onMoveShouldSetResponder={() => {
-            clearTimeout(this.closePickerTimeout)
-            return true
+            clearTimeout(this.closePickerTimeout);
+            return true;
            }}
           style={{height: this.state.height, overflow: 'hidden'}}
         >
@@ -75,9 +75,9 @@ class CollapsiblePickerIOS extends React.Component {
             style={selectStyle}
             selectedValue={locals.value}
             onValueChange={(itemValue, itemPosition) => {
-              clearTimeout(this.closePickerTimeout)
-              this.closePickerTimeout = setTimeout(closePicker, 500)
-              locals.onChange(itemValue, itemPosition)
+              clearTimeout(this.closePickerTimeout);
+              this.closePickerTimeout = setTimeout(closePicker, 500);
+              locals.onChange(itemValue, itemPosition);
             }}
             help={locals.help}
             enabled={locals.enabled}

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -70,7 +70,7 @@ class CollapsiblePickerIOS extends React.Component {
             selectedValue={locals.value}
             onValueChange={(itemValue, itemPosition) => {
               clearTimeout(this.closePickerTimeout)
-              this.closePickerTimeout = setTimeout(closePicker, 800)
+              this.closePickerTimeout = setTimeout(closePicker, 2000)
               locals.onChange(itemValue, itemPosition)
             }}
             help={locals.help}


### PR DESCRIPTION
@alvaromb mentioned he'd take a pull request for this in #265 
Currently, when presenting an enum in the form the default template provides a Picker on iOS.
This picker stays open after the user selects an option instead of automatically closing.

This pull request closes the picker 500ms after the user stops interacting with the Picker.
It detects pans on the View surrounding the Picker to ensure it doesn't close if the user is still panning the Picker after a selection is made, be it they are scrolling lower in the list or simply hovering over options.