### PR TITLE
Bug Fix:  TypeError: props.date.getTime is not a function when set DMY date format  to date picker

### DIFF
--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -76,7 +76,7 @@ class CollapsibleDatePickerIOS extends React.Component {
           <DatePickerIOS
             ref="input"
             accessibilityLabel={locals.label}
-            date={locals.value}
+            date={new Date(locals.value)}
             maximumDate={locals.maximumDate}
             minimumDate={locals.minimumDate}
             minuteInterval={locals.minuteInterval}


### PR DESCRIPTION
When i set dmy value to any date picker ios,  i get error message as below:
ExceptionsManager.js:65 TypeError: props.date.getTime is not a function
This error is located at: in DatePickerIOS (at datepicker.ios.js:76)

Reason: tcomb converts dmy date to string but DatepickerIOS can not recognise it