### PR TITLE
Fix DatePicker default value is null

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -414,7 +414,7 @@ class DatePicker extends Component {
 }
 
 DatePicker.transformer = {
-  format: value => (Nil.is(value) ? new Date() : value),
+  format: value => (Nil.is(value) ? null : value),
   parse: value => value
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -990,7 +990,7 @@ test("DatePicker:help", function(tape) {
 });
 
 test("DatePicker:value", function(tape) {
-  tape.plan(1);
+  tape.plan(2);
 
   tape.strictEqual(
     new DatePicker({
@@ -1001,6 +1001,17 @@ test("DatePicker:value", function(tape) {
     }).getLocals().value,
     date,
     "should handle value option"
+  );
+
+  tape.strictEqual(
+    new DatePicker({
+      type: t.Date,
+      options: {},
+      ctx: ctx,
+      value: null
+    }).getLocals().value,
+    null,
+    "default value should be null when empty"
   );
 });
 


### PR DESCRIPTION
As with other a majority of the other components (`Textbox`, `Checkbox` and `Select`), if the default value is empty it returns `null | false` but the `DatePicker` defaults to the current date (`new Date()`) when no date is provided.

These changes default it to `null` when the value is considered empty/nil.