### PR TITLE
Adds `autoGrow` support to the textbox template

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,7 @@ The following standard options are available (see http://facebook.github.io/reac
 - `autoCapitalize`
 - `autoCorrect`
 - `autoFocus`
+- `autoGrow`
 - `bufferDelay`
 - `clearButtonMode`
 - `editable`

--- a/lib/components.js
+++ b/lib/components.js
@@ -273,6 +273,7 @@ class Textbox extends Component {
       "autoCapitalize",
       "autoCorrect",
       "autoFocus",
+      "autoGrow",
       "blurOnSubmit",
       "editable",
       "maxLength",

--- a/lib/stylesheets/bootstrap.js
+++ b/lib/stylesheets/bootstrap.js
@@ -70,7 +70,7 @@ var stylesheet = Object.freeze({
     normal: {
       color: INPUT_COLOR,
       fontSize: FONT_SIZE,
-      height: 36,
+      minHeight: 36, // To support autoGrow prop
       paddingVertical: Platform.OS === "ios" ? 7 : 0,
       paddingHorizontal: 7,
       borderRadius: 4,
@@ -82,7 +82,7 @@ var stylesheet = Object.freeze({
     error: {
       color: INPUT_COLOR,
       fontSize: FONT_SIZE,
-      height: 36,
+      minHeight: 36, // To support autoGrow prop
       paddingVertical: Platform.OS === "ios" ? 7 : 0,
       paddingHorizontal: 7,
       borderRadius: 4,
@@ -93,7 +93,7 @@ var stylesheet = Object.freeze({
     // the style applied when the textbox is not editable
     notEditable: {
       fontSize: FONT_SIZE,
-      height: 36,
+      minHeight: 36, // To support autoGrow prop
       paddingVertical: Platform.OS === "ios" ? 7 : 0,
       paddingHorizontal: 7,
       borderRadius: 4,

--- a/lib/templates/bootstrap/textbox.js
+++ b/lib/templates/bootstrap/textbox.js
@@ -50,6 +50,7 @@ function textbox(locals) {
           autoCapitalize={locals.autoCapitalize}
           autoCorrect={locals.autoCorrect}
           autoFocus={locals.autoFocus}
+          autoGrow={locals.autoGrow}
           blurOnSubmit={locals.blurOnSubmit}
           editable={locals.editable}
           keyboardType={locals.keyboardType}

--- a/test/index.js
+++ b/test/index.js
@@ -12,6 +12,7 @@ var bootstrap = {
 };
 
 var core = require("../lib/components");
+var stylesheet = require("../lib/stylesheets/bootstrap");
 import { UIDGenerator } from "../lib/util";
 
 var ctx = {
@@ -374,6 +375,32 @@ test("Textbox:template", function(tape) {
     }).getTemplate(),
     template,
     "should handle template option"
+  );
+});
+
+test("Textbox:autoGrow", function(tape) {
+  tape.plan(2);
+
+  tape.strictEqual(
+    new Textbox({
+      type: t.String,
+      options: {},
+      ctx: ctx
+    }).getLocals().autoGrow,
+    undefined,
+    "default autoGrow should be undefined"
+  );
+
+  tape.strictEqual(
+    new Textbox({
+      type: t.String,
+      options: {
+        autoGrow: true
+      },
+      ctx: ctx
+    }).getLocals().autoGrow,
+    true,
+    "should handle autoGrow option"
   );
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@
 
 var test = require("tape");
 var t = require("tcomb-validation");
+var mockRequire = require("mock-require");
 var bootstrap = {
   checkbox: function() {},
   datepicker: function() {},
@@ -12,6 +13,14 @@ var bootstrap = {
 };
 
 var core = require("../lib/components");
+mockRequire("react-native", {
+  Platform: {
+    OS: "ios",
+    select: function(obj) {
+      return obj.ios || {}
+    }
+  }
+})
 var stylesheet = require("../lib/stylesheets/bootstrap");
 import { UIDGenerator } from "../lib/util";
 
@@ -379,7 +388,7 @@ test("Textbox:template", function(tape) {
 });
 
 test("Textbox:autoGrow", function(tape) {
-  tape.plan(2);
+  tape.plan(8);
 
   tape.strictEqual(
     new Textbox({
@@ -401,6 +410,31 @@ test("Textbox:autoGrow", function(tape) {
     }).getLocals().autoGrow,
     true,
     "should handle autoGrow option"
+  );
+
+  tape.ok(
+    "minHeight" in stylesheet.textbox.normal,
+    "should use minHeight for textbox normal style"
+  );
+  tape.notOk(
+    "height" in stylesheet.textbox.normal,
+    "should not use height for textbox normal style"
+  );
+  tape.ok(
+    "minHeight" in stylesheet.textbox.error,
+    "should use minHeight for textbox error style"
+  );
+  tape.notOk(
+    "height" in stylesheet.textbox.error,
+    "should not use height for textbox error style"
+  );
+  tape.ok(
+    "minHeight" in stylesheet.textbox.notEditable,
+    "should use minHeight for textbox notEditable style"
+  );
+  tape.notOk(
+    "height" in stylesheet.textbox.notEditable,
+    "should not use height for textbox notEditable style"
   );
 });
 


### PR DESCRIPTION
The current implementation allows the `multiline` prop on the textbox template but has no support for the `autoGrow` prop. This PR addresses the issue, and so allows a multiline, autogrowing textbox component to be configured.