### PR TITLE
Allow list values to be raw strings. Fixes #289

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -615,9 +615,14 @@ export class List extends Component {
     }
 
     for (let i = 0, len = this.state.value.length; i < len; i++) {
-      result = this.refs[i].validate();
-      errors = errors.concat(result.errors);
-      value.push(result.value);
+      const ref = this.refs[i];
+      if(ref) {
+        result = this.refs[i].validate();
+        errors = errors.concat(result.errors);
+        value.push(result.value);
+      } else {
+        value.push(this.state.value[i]);
+      }
     }
 
     // handle subtype

--- a/test/index.js
+++ b/test/index.js
@@ -1213,3 +1213,28 @@ test("List:should support unions", assert => {
 
   assert.strictEqual(component.getItems()[0].input.props.type, UnknownAccount);
 });
+
+test("List:should support validation using string values", assert => {
+  let component = new List({
+    type: t.list(t.String),
+    ctx: ctx,
+    options: {},
+    value: [
+      "item 1",
+      "item 2"
+    ]
+  });
+  try {
+    assert.plan(2);
+
+    const validationResult = component.validate();
+
+    assert.deepEqual(validationResult.value, [
+      "item 1",
+      "item 2"
+    ]);
+    assert.deepEqual(validationResult.errors, []);
+  } catch(e) {
+    assert.fail("Should not throw an exception");
+  }
+});


### PR DESCRIPTION
This fixes the issue exactly as described in #289.

The result is that you can use the following schema options:

``` js

const options = {
  fields: {
    photos: {
      template: MultiPhotoTemplate
    }
  }
};
```

with the following template:

class MultiPhotoTemplate extends React.Component {
  render() {
    const { value } = this.props;
    // Here, 'value' is an array of strings, so do what you need to do with them.
    // To update the form field, call `this.props.onChange(newValue)`, where
    // `newValue` is an array of strings.
  }
}
```