### PR TITLE
add testID to textInput and checkbox

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -293,7 +293,8 @@ class Textbox extends Component {
       "keyboardAppearance",
       "onKeyPress",
       "returnKeyType",
-      "selectionState"
+      "selectionState",
+      "testID"
     ].forEach(name => (locals[name] = this.props.options[name]));
 
     return locals;
@@ -375,7 +376,7 @@ class Select extends Component {
     const locals = super.getLocals();
     locals.options = this.getOptions();
 
-    ["help", "enabled", "mode", "prompt", "itemStyle"].forEach(
+    ["help", "enabled", "mode", "prompt", "itemStyle", "testID"].forEach(
       name => (locals[name] = this.props.options[name])
     );
 

--- a/lib/templates/bootstrap/checkbox.js
+++ b/lib/templates/bootstrap/checkbox.js
@@ -39,6 +39,7 @@ function checkbox(locals) {
       <Switch
         accessibilityLabel={locals.label}
         ref="input"
+        testID={locals.testID}
         disabled={locals.disabled}
         onTintColor={locals.onTintColor}
         thumbTintColor={locals.thumbTintColor}

--- a/lib/templates/bootstrap/textbox.js
+++ b/lib/templates/bootstrap/textbox.js
@@ -79,6 +79,7 @@ function textbox(locals) {
           onChange={locals.onChangeNative}
           placeholder={locals.placeholder}
           style={textboxStyle}
+          testID={locals.testID}
           value={locals.value}
         />
       </View>


### PR DESCRIPTION
There were 2 issues about this, but nobody submitted a pull request. 

Basically to write tests one needs testID attached to the RN element. testID is property of RN View, so in my opinion we should also add it directly in the props. So no config: {testID} etc, but just 

testID: "whatever"

this attaches it to the TextBox

With this change one could use libraries such as detox to test his form (at least for TextInput)