### PR TITLE
fix: handle `label` option with `i18n`

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -30,7 +30,9 @@ function getFormComponent(type, options) {
     case "irreducible":
       return type === t.Boolean
         ? Checkbox
-        : type === t.Date ? DatePicker : Textbox;
+        : type === t.Date
+          ? DatePicker
+          : Textbox;
     case "struct":
       return Struct;
     case "list":
@@ -152,6 +154,12 @@ class Component extends React.Component {
     let label = this.props.options.label || this.props.options.legend;
     if (Nil.is(label) && this.getAuto() === "labels") {
       label = this.getDefaultLabel();
+    } else {
+      label =
+        label +
+        (this.typeInfo.isMaybe
+          ? this.getI18n().optional
+          : this.getI18n().required);
     }
     return label;
   }
@@ -203,8 +211,9 @@ class Component extends React.Component {
     // getTemplate is the only required implementation when extending Component
     t.assert(
       t.Function.is(this.getTemplate),
-      `[${SOURCE}] missing getTemplate method of component ${this.constructor
-        .name}`
+      `[${SOURCE}] missing getTemplate method of component ${
+        this.constructor.name
+      }`
     );
     const template = this.getTemplate();
     return template(locals);

--- a/test/index.js
+++ b/test/index.js
@@ -42,7 +42,7 @@ var ctxNone = {
 var Textbox = core.Textbox;
 
 test("Textbox:label", function(tape) {
-  tape.plan(3);
+  tape.plan(4);
 
   tape.strictEqual(
     new Textbox({
@@ -72,6 +72,16 @@ test("Textbox:label", function(tape) {
     }).getLocals().label,
     "ctxDefaultLabel (optional)",
     "should handle optional types"
+  );
+
+  tape.strictEqual(
+    new Textbox({
+      type: t.maybe(t.String),
+      options: { label: "mylabel" },
+      ctx: ctx
+    }).getLocals().label,
+    "mylabel (optional)",
+    "should handle `label` option with optional types"
   );
 });
 


### PR DESCRIPTION
When adding `label` via `option` i18n parameters are not taken in
account.

attempt to fix #418