### PR TITLE
Remove reference to `title` style in Example App

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,6 @@ var styles = StyleSheet.create({
     padding: 20,
     backgroundColor: '#ffffff',
   },
-  title: {
-    fontSize: 30,
-    alignSelf: 'center',
-    marginBottom: 30
-  },
   buttonText: {
     fontSize: 18,
     color: 'white',


### PR DESCRIPTION
I was reading the README and noticed a dead style object in the example app, the `title` style is not used.