### PR TITLE
Added allowFontScaling as an option for TextBox 

### DIFF
--- a/README.md
+++ b/README.md
@@ -860,6 +860,7 @@ Age.getValidationErrorMessage = function (value, path, context) {
 
 The following standard options are available (see http://facebook.github.io/react-native/docs/textinput.html):
 
+- `allowFontScaling`
 - `autoCapitalize`
 - `autoCorrect`
 - `autoFocus`

--- a/lib/components.js
+++ b/lib/components.js
@@ -270,6 +270,7 @@ class Textbox extends Component {
       this.props.options.underlineColorAndroid || "transparent";
     [
       "help",
+      "allowFontScaling",
       "autoCapitalize",
       "autoCorrect",
       "autoFocus",

--- a/lib/templates/bootstrap/textbox.js
+++ b/lib/templates/bootstrap/textbox.js
@@ -47,6 +47,7 @@ function textbox(locals) {
         <TextInput
           accessibilityLabel={locals.label}
           ref="input"
+          allowFontScaling={locals.allowFontScaling}
           autoCapitalize={locals.autoCapitalize}
           autoCorrect={locals.autoCorrect}
           autoFocus={locals.autoFocus}


### PR DESCRIPTION
This is needed if one wants to keep the size constant when "Larger Text" option is enabled from "Accessibility".

http://facebook.github.io/react-native/docs/textinput#allowfontscaling