### PR TITLE
added testid to switch and textbox

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -296,7 +296,8 @@ class Textbox extends Component {
       "keyboardAppearance",
       "onKeyPress",
       "returnKeyType",
-      "selectionState"
+      "selectionState",
+      "testID"
     ].forEach(name => (locals[name] = this.props.options[name]));
 
     return locals;
@@ -324,7 +325,7 @@ class Checkbox extends Component {
       this.props.ctx.auto !== "none"
         ? locals.label || this.getDefaultLabel()
         : null;
-    ["help", "disabled", "onTintColor", "thumbTintColor", "tintColor"].forEach(
+    ["help", "disabled", "onTintColor", "thumbTintColor", "tintColor", "testID"].forEach(
       name => (locals[name] = this.props.options[name])
     );
 
@@ -384,7 +385,8 @@ class Select extends Component {
       "prompt",
       "itemStyle",
       "isCollapsed",
-      "onCollapseChange"
+      "onCollapseChange",
+      "testID"
     ].forEach(name => (locals[name] = this.props.options[name]));
 
     return locals;

--- a/lib/templates/bootstrap/checkbox.js
+++ b/lib/templates/bootstrap/checkbox.js
@@ -46,6 +46,7 @@ function checkbox(locals) {
         style={checkboxStyle}
         onValueChange={value => locals.onChange(value)}
         value={locals.value}
+        testID={locals.testID}
       />
       {help}
       {error}

--- a/lib/templates/bootstrap/textbox.js
+++ b/lib/templates/bootstrap/textbox.js
@@ -80,6 +80,7 @@ function textbox(locals) {
           placeholder={locals.placeholder}
           style={textboxStyle}
           value={locals.value}
+          testID={locals.testID}
         />
       </View>
       {help}


### PR DESCRIPTION
Attaches a testID to textbox and switch components

This is useful for e2e tests because there's no other way to select those components