### PR TITLE
[iOS only]: Handling UI transactions  to show hide keyboard or picker/checkbox

### DIFF
--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -29,7 +29,6 @@ class CollapsibleDatePickerIOS extends React.Component {
 
   componentWillUnmount() {
 		this.keyboardWillShowSub.remove()
-		this.keyboardWillHideSub.remove()
 	}
 
 

--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -5,7 +5,8 @@ import {
   View,
   Animated,
   DatePickerIOS,
-  TouchableOpacity
+  TouchableOpacity,
+  Keyboard
 } from "react-native";
 
 const UIPICKER_HEIGHT = 216;
@@ -17,7 +18,8 @@ class CollapsibleDatePickerIOS extends React.Component {
     this._onPress = this.onPress.bind(this);
     this.state = {
       isCollapsed: true,
-      height: new Animated.Value(0)
+      height: new Animated.Value(0),
+      keyboardState: false
     };
   }
 
@@ -25,7 +27,32 @@ class CollapsibleDatePickerIOS extends React.Component {
     this.props.locals.onChange(value);
   }
 
+  componentWillUnmount() {
+		this.keyboardWillShowSub.remove()
+		this.keyboardWillHideSub.remove()
+	}
+
+
+  componentDidMount () {
+    this.keyboardWillShowSub = Keyboard.addListener('keyboardWillShow', () => {
+      this.setState({isCollapsed: false}, () => {
+        const animation = Animated.timing;
+        const animationConfig = {duration: 200};
+        animation(
+          this.state.height,
+          Object.assign(
+            {
+              toValue: this.state.isCollapsed ? UIPICKER_HEIGHT : 0
+            },
+            animationConfig
+          )
+        ).start();
+      })
+    })
+  }
+
   onPress() {
+    Keyboard.dismiss()
     const locals = this.props.locals;
     let animation = Animated.timing;
     let animationConfig = {

--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -9,6 +9,7 @@ import {
   Keyboard
 } from "react-native";
 
+
 const UIPICKER_HEIGHT = 216;
 
 class CollapsibleDatePickerIOS extends React.Component {
@@ -19,7 +20,7 @@ class CollapsibleDatePickerIOS extends React.Component {
     this.state = {
       isCollapsed: true,
       height: new Animated.Value(0),
-      keyboardState: false
+      pickerStateUpdaterKeyboard: false
     };
   }
 
@@ -34,7 +35,7 @@ class CollapsibleDatePickerIOS extends React.Component {
 
   componentDidMount () {
     this.keyboardWillShowSub = Keyboard.addListener('keyboardWillShow', () => {
-      this.setState({isCollapsed: false}, () => {
+      this.setState({isCollapsed: false, pickerStateUpdaterKeyboard: true}, () => {
         const animation = Animated.timing;
         const animationConfig = {duration: 200};
         animation(
@@ -51,6 +52,8 @@ class CollapsibleDatePickerIOS extends React.Component {
   }
 
   onPress() {
+    let { height, isCollapsed, pickerStateUpdaterKeyboard } = this.state
+    console.log(`Height:`, height, `isCollapsed:`, isCollapsed, `pickerStateUpdaterKeyboard:`, pickerStateUpdaterKeyboard)
     Keyboard.dismiss()
     const locals = this.props.locals;
     let animation = Animated.timing;
@@ -65,16 +68,20 @@ class CollapsibleDatePickerIOS extends React.Component {
         animationConfig = locals.config.animationConfig;
       }
     }
+    if (pickerStateUpdaterKeyboard) {
+      pickerStateUpdaterKeyboard = false
+      isCollapsed = true
+    }
     animation(
-      this.state.height,
+      height,
       Object.assign(
         {
-          toValue: this.state.isCollapsed ? UIPICKER_HEIGHT : 0
+          toValue: isCollapsed ? UIPICKER_HEIGHT : 0
         },
         animationConfig
       )
     ).start();
-    this.setState({ isCollapsed: !this.state.isCollapsed });
+    this.setState({ isCollapsed: !isCollapsed, pickerStateUpdaterKeyboard: false});
     if (typeof locals.onPress === "function") {
       locals.onPress();
     }

--- a/lib/templates/bootstrap/datepicker.ios.js
+++ b/lib/templates/bootstrap/datepicker.ios.js
@@ -53,7 +53,6 @@ class CollapsibleDatePickerIOS extends React.Component {
 
   onPress() {
     let { height, isCollapsed, pickerStateUpdaterKeyboard } = this.state
-    console.log(`Height:`, height, `isCollapsed:`, isCollapsed, `pickerStateUpdaterKeyboard:`, pickerStateUpdaterKeyboard)
     Keyboard.dismiss()
     const locals = this.props.locals;
     let animation = Animated.timing;

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Animated, View, TouchableOpacity, Text, Picker } from "react-native";
+import { Animated, View, TouchableOpacity, Text, Picker, Keyboard } from "react-native";
 
 const UIPICKER_HEIGHT = 216;
 
@@ -47,6 +47,7 @@ class CollapsiblePickerIOS extends React.Component {
   }
 
   _togglePicker() {
+    Keyboard.dismiss()
     this.setState({ isCollapsed: !this.state.isCollapsed }, () => {
       this.animatePicker(this.state.isCollapsed);
       if (typeof this.props.locals.onCollapseChange === "function") {


### PR DESCRIPTION
This will close picker/checkbox if the user clicks on a field which requires Keyboard to appear and vice versa, it will close the keyboard if the user clicks on checkbox/picker. 