### PR TITLE
Update to componentDidUpdate

### DIFF
--- a/lib/components.js
+++ b/lib/components.js
@@ -81,7 +81,7 @@ class Component extends React.Component {
     return should;
   }
 
-  componentWillReceiveProps(props) {
+  componentDidUpdate(props) {
     if (props.type !== this.props.type) {
       this.typeInfo = getTypeInfo(props.type);
     }
@@ -592,7 +592,7 @@ export class List extends Component {
     this.state.keys = this.state.value.map(() => props.ctx.uidGenerator.next());
   }
 
-  componentWillReceiveProps(props) {
+  componentDidUpdate(props) {
     if (props.type !== this.props.type) {
       this.typeInfo = getTypeInfo(props.type);
     }


### PR DESCRIPTION
Replacing componentWillReceiveProps with componentDidUpdate due to:
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.