### PR TITLE
feat(picker): import picker from community lib

### DIFF
--- a/lib/templates/bootstrap/select.android.js
+++ b/lib/templates/bootstrap/select.android.js
@@ -1,5 +1,6 @@
 var React = require("react");
-var { View, Text, Picker } = require("react-native");
+var { View, Text } = require("react-native");
+var { Picker } = require("@react-native-picker/picker");
 
 function select(locals) {
   if (locals.hidden) {

--- a/lib/templates/bootstrap/select.ios.js
+++ b/lib/templates/bootstrap/select.ios.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Animated, View, TouchableOpacity, Text, Picker } from "react-native";
+import { Animated, View, TouchableOpacity, Text } from "react-native";
+import { Picker } from "@react-native-picker/picker";
 
 const UIPICKER_HEIGHT = 216;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tcomb-form-native",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "description":
     "react-native powered UI library for developing forms writing less code",
   "main": "index.js",


### PR DESCRIPTION
Picker component does not exist on react-native lts version > 0.66. It must be imported from react-native-picker/picker library.
For now on, this picker community lib must be installed in the project.